### PR TITLE
Fix atlas operator kustomization

### DIFF
--- a/clusters/home-pc/atlas-operator/kustomization.yaml
+++ b/clusters/home-pc/atlas-operator/kustomization.yaml
@@ -1,8 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-dependsOn:
-  - name: external-secrets-operator
-    namespace: flux-system
 resources:
   - atlas-oparator-helm.yaml
   - atlas-db-url-secret.yaml

--- a/clusters/home-pc/flux-system/atlas-operator-kustomization.yaml
+++ b/clusters/home-pc/flux-system/atlas-operator-kustomization.yaml
@@ -4,6 +4,9 @@ metadata:
   name: atlas-operator
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: external-secrets-operator
+      namespace: flux-system
   interval: 10m
   path: ./clusters/home-pc/atlas-operator
   prune: true


### PR DESCRIPTION
## Summary
- remove unsupported `dependsOn` from atlas operator kustomization
- add `dependsOn` to the Flux Kustomization so external-secrets is ready first

## Testing
- `kubectl kustomize clusters/home-pc` *(fails: `kubectl: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68504f139cbc832ca4dfa3e1f271aac3