### PR TITLE
Add n8n database user creation job

### DIFF
--- a/clusters/home-pc/flux-system/kustomization.yaml
+++ b/clusters/home-pc/flux-system/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - nginx-ingress-kustomization.yaml
   - atlas-operator-kustomization.yaml
   - pg-operator-kustomization.yaml
+  - n8n-user-job-kustomization.yaml

--- a/clusters/home-pc/flux-system/n8n-user-job-kustomization.yaml
+++ b/clusters/home-pc/flux-system/n8n-user-job-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: n8n-user-job
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: pg-operator
+      namespace: flux-system
+    - name: external-secrets-resources
+      namespace: flux-system
+  interval: 10m
+  path: ./clusters/home-pc/n8n-job
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true

--- a/clusters/home-pc/n8n-job/create-n8n-user-job.yaml
+++ b/clusters/home-pc/n8n-job/create-n8n-user-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-n8n-user
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: psql
+        image: postgres:16
+        env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: psql-owner-password
+              key: password
+        - name: N8N_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: n8n-user-password
+              key: password
+        command: ["sh", "-c"]
+        args:
+          - |
+            psql -h db-cluster-rw.default.svc.cluster.local -U owner -d postgres -c \
+            "DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n8nuser') THEN CREATE ROLE n8nuser WITH LOGIN PASSWORD '${N8N_PASSWORD}'; END IF; END $$;"
+      restartPolicy: OnFailure

--- a/clusters/home-pc/n8n-job/kustomization.yaml
+++ b/clusters/home-pc/n8n-job/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The Flux Kustomization that applies this directory specifies dependsOn for
+# the PostgreSQL cluster and external secrets resources. This base simply lists
+# the job manifest.
+resources:
+  - create-n8n-user-job.yaml


### PR DESCRIPTION
## Summary
- create job to create an `n8n` user in PostgreSQL
- configure Flux with a kustomization that waits for the database and secrets
- document dependencies in the job kustomization

## Testing
- `./kustomize build clusters/home-pc/n8n-job`
- `./kustomize build clusters/home-pc/external-secrets-operator/resources`
- `./kustomize build clusters/home-pc/flux-system`


------
https://chatgpt.com/codex/tasks/task_e_6852d442ce88832cbedd6a16ef3e5b51