### PR TITLE
Add database creation to n8n user job

### DIFF
--- a/clusters/home-pc/n8n-job/create-n8n-user-job.yaml
+++ b/clusters/home-pc/n8n-job/create-n8n-user-job.yaml
@@ -23,6 +23,19 @@ spec:
         command: ["sh", "-c"]
         args:
         - |
+          set -euo pipefail
+          echo "Checking if n8nuser exists or needs to be created"
           psql -h db-cluster-rw.default.svc.cluster.local -U owner -d postgres -c \
           "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'n8nuser') THEN CREATE ROLE n8nuser WITH LOGIN PASSWORD '${N8N_PASSWORD}'; END IF; END \$\$;"
+          echo "n8n user setup completed"
+          echo "Checking if n8n database exists"
+          if ! psql -h db-cluster-rw.default.svc.cluster.local -U owner -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname = 'n8n'" | grep -q 1; then
+            echo "Creating n8n database"
+            psql -h db-cluster-rw.default.svc.cluster.local -U owner -d postgres -c "CREATE DATABASE n8n OWNER n8nuser;"
+          else
+            echo "n8n database already exists"
+          fi
+          echo "Granting privileges on n8n database to n8nuser"
+          psql -h db-cluster-rw.default.svc.cluster.local -U owner -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE n8n TO n8nuser;"
+          echo "n8n database setup completed"
       restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
- expand the create-n8n-user job to also create and grant access to the n8n database
- log each step during user and database setup

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6852f1bf6d8c832c9aed142e8f70a898