### PR TITLE
UTR-000172 fix HelmRepository namespace override

### DIFF
--- a/clusters/may-chang/observability-resources/kustomization.yaml
+++ b/clusters/may-chang/observability-resources/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: observability
+# All resources here already declare `metadata.namespace: observability`
+# explicitly; the top-level kustomize namespace is intentionally omitted to
+# stay consistent with clusters/may-chang/observability/kustomization.yaml.
 
 # Grafana CRs are reconciled only by the dedicated `observability-resources`
 # Flux Kustomization (dependsOn: observability). They are intentionally NOT
@@ -14,15 +16,19 @@ resources:
 
 configMapGenerator:
   - name: utro-dashboard-services
+    namespace: observability
     files:
       - utro-services.json
   - name: utro-dashboard-traces
+    namespace: observability
     files:
       - utro-traces.json
   - name: utro-dashboard-db-pool
+    namespace: observability
     files:
       - utro-db-pool.json
   - name: utro-dashboard-db-queries
+    namespace: observability
     files:
       - utro-db-queries.json
 

--- a/clusters/may-chang/observability/kustomization.yaml
+++ b/clusters/may-chang/observability/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: observability
+# No top-level `namespace:` field: HelmRepositories must live in flux-system
+# (where the helm-controller resolves `sourceRef`), while everything else
+# already declares `metadata.namespace: observability` explicitly. A global
+# kustomize-level namespace would override the flux-system one and break the
+# HelmReleases.
 
 # This directory only holds CRD-safe resources (namespace, ExternalSecrets,
 # HelmRepository/HelmRelease, Certificate, ClusterRole/CronJob, etc.) — every


### PR DESCRIPTION
## Summary

- After PR #8 merged, HelmReleases stalled with `HelmRepository ... not found`. Cause: the kustomize-level `namespace: observability` field overrode `metadata.namespace: flux-system` on the three HelmRepository manifests, so they were created in `observability` instead of `flux-system` (where helm-controller resolves `sourceRef`).
- Drop the top-level `namespace:` from both `observability/` and `observability-resources/` kustomizations — every resource file already declares its own namespace explicitly.
- Add explicit `namespace: observability` to each `configMapGenerator` entry so the four dashboard ConfigMaps still land in the right namespace (they would otherwise fall back to `default`).

## Test plan

- [x] `kubectl kustomize clusters/may-chang/observability/` exits 0; rendered HelmRepository resources are in `namespace: flux-system`
- [x] `kubectl kustomize clusters/may-chang/observability-resources/` exits 0; rendered ConfigMaps are in `namespace: observability`
- [ ] After merge: `flux reconcile kustomization observability` succeeds; the wrongly-placed HelmRepositories in the `observability` namespace are pruned
- [ ] All five HelmReleases (`kube-prometheus-stack`, `loki`, `promtail`, `tempo`, `grafana-operator`) reach `Ready: True`
- [ ] `observability-resources` Kustomization reaches `Ready: True` once operator CRDs are installed
- [ ] `grafana-nginx-proxy` pod stops CrashLoopBackOff once the Grafana CR creates the upstream service

🤖 Generated with [Claude Code](https://claude.com/claude-code)