### PR TITLE
UTR-000172 move tempo extraEnvFrom under tempo: block

### DIFF
--- a/clusters/may-chang/observability/helmrelease-tempo.yaml
+++ b/clusters/may-chang/observability/helmrelease-tempo.yaml
@@ -31,16 +31,20 @@ spec:
       limits:
         memory: 2Gi
 
-    # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are injected from the
-    # `tempo-s3-credentials` Secret (synced via ExternalSecret). Bucket
-    # name is the deterministic one created by Terraform.
-    extraEnvFrom:
-      - secretRef:
-          name: tempo-s3-credentials
-
     # Tempo monolithic config
     tempo:
       retention: 336h  # 14 days
+
+      # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are injected from the
+      # `tempo-s3-credentials` Secret (synced via ExternalSecret). The Tempo
+      # binary's AWS SDK picks them up automatically. Bucket name is the
+      # deterministic one created by Terraform.
+      # NOTE: `extraEnvFrom` belongs UNDER the `tempo:` block in this chart
+      # (v1.24.x), not at the top level — the chart's templates only inject
+      # env from `tempo.extraEnvFrom`.
+      extraEnvFrom:
+        - secretRef:
+            name: tempo-s3-credentials
 
       receivers:
         otlp:


### PR DESCRIPTION
## Summary

The `grafana/tempo` chart at v1.24.x only injects environment from `tempo.extraEnvFrom`, **not** a top-level `extraEnvFrom`. With the key at the top level (where I originally put it), `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` never reached the container — `kubectl get pod tempo-0 -o jsonpath='{.spec.containers[0].envFrom}'` returned empty.

Tempo's AWS SDK fell back to anonymous and got `Access Denied` listing `utro-tempo-traces`; CrashLoopBackOff with:

```
err="failed to init module services: error initialising module: optional-store:
failed to create store: unexpected error from ListObjects on utro-tempo-traces:
Access Denied"
```

Verified by `helm pull grafana/tempo --version 1.24.4 --untar` and reading `values.yaml:192` — the key lives at `tempo.extraEnvFrom`.

## Test plan

- [x] `kubectl kustomize clusters/may-chang/observability/` renders the tempo HelmRelease with `tempo.extraEnvFrom` nested under the `tempo:` block
- [ ] After merge: `kubectl -n observability get pod tempo-0 -o jsonpath='{.spec.containers[0].envFrom}'` shows the `tempo-s3-credentials` secret ref
- [ ] Tempo logs show `Tempo started` (no Access Denied), pod transitions to Running
- [ ] `kubectl -n observability get helmrelease tempo` shows `Ready: True`
- [ ] `observability` Kustomization reaches `Ready: True`, unblocking `observability-resources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)