### PR TITLE
UTR-000172 add host + cluster resource dashboards

### DIFF
--- a/clusters/may-chang/observability-resources/infrastructure-dashboards.yaml
+++ b/clusters/may-chang/observability-resources/infrastructure-dashboards.yaml
@@ -1,0 +1,79 @@
+# Host + cluster resource dashboards pulled from grafana.com via the operator.
+# Using grafanaCom.id avoids vendoring large dashboard JSON blobs into the repo.
+#
+# Dashboards rely on metrics emitted by:
+#   - node-exporter (DaemonSet, installed by kube-prometheus-stack)
+#   - kube-state-metrics (Deployment, installed by kube-prometheus-stack)
+#   - the kubelet/cAdvisor scrape targets the chart wires up
+#
+# All three need the `cluster` external label, which is set on Prometheus via
+# clusters/may-chang/observability/helmrelease-kube-prometheus-stack.yaml.
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: infrastructure-folder
+  namespace: observability
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  title: Infrastructure
+---
+# Canonical node-exporter dashboard. Host-level CPU / memory / disk / network /
+# file descriptors / per-CPU breakdowns / systemd. ~30 panels, well maintained.
+# https://grafana.com/grafana/dashboards/1860
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: node-exporter-full
+  namespace: observability
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: infrastructure-folder
+  resyncPeriod: 5m
+  grafanaCom:
+    id: 1860
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: prometheus
+---
+# Cluster-wide rollup: CPU/mem/pod count/PVCs across all nodes.
+# https://grafana.com/grafana/dashboards/15757
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-views-global
+  namespace: observability
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: infrastructure-folder
+  resyncPeriod: 5m
+  grafanaCom:
+    id: 15757
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: prometheus
+---
+# Per-node breakdown: CPU/mem requests vs usage, pod density, conditions.
+# https://grafana.com/grafana/dashboards/15759
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: k8s-views-nodes
+  namespace: observability
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: infrastructure-folder
+  resyncPeriod: 5m
+  grafanaCom:
+    id: 15759
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: prometheus

--- a/clusters/may-chang/observability-resources/kustomization.yaml
+++ b/clusters/may-chang/observability-resources/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
   - grafana.yaml
   - grafana-datasources.yaml
   - grafana-dashboards.yaml
+  # Host + cluster resource dashboards (Node Exporter Full + dotdc K8s views).
+  - infrastructure-dashboards.yaml
   # Tailscale exposure for Grafana — same Kustomization as the Grafana CR
   # so nginx's upstream (the Service the operator creates from the CR) is
   # applied in the same batch. Avoids the nginx-stuck-without-upstream

--- a/clusters/may-chang/observability/helmrelease-kube-prometheus-stack.yaml
+++ b/clusters/may-chang/observability/helmrelease-kube-prometheus-stack.yaml
@@ -40,6 +40,12 @@ spec:
       prometheusSpec:
         retention: 14d
         retentionSize: ""
+        # `cluster` external label so community dashboards that filter on
+        # $cluster (dotdc/grafana-dashboards-kubernetes etc.) have a value
+        # to bind to. Multi-cluster Prometheus federations also rely on
+        # this label to disambiguate sources.
+        externalLabels:
+          cluster: may-chang
         serviceMonitorSelectorNilUsesHelmValues: false
         podMonitorSelectorNilUsesHelmValues: false
         ruleSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## Summary

Adds three host/cluster resource dashboards in a new `Infrastructure` folder, pulled from grafana.com via the operator's `grafanaCom.id` import (no JSON vendored):

| ID | Name | What |
|---|---|---|
| [1860](https://grafana.com/grafana/dashboards/1860) | Node Exporter Full | Host-level CPU / mem / disk / network / fd / per-CPU / systemd |
| [15757](https://grafana.com/grafana/dashboards/15757) | Kubernetes / Views / Global | Cluster-wide rollup |
| [15759](https://grafana.com/grafana/dashboards/15759) | Kubernetes / Views / Nodes | Per-node breakdown |

All three are pre-mapped to the existing `prometheus` GrafanaDatasource via `spec.datasources[].inputName: DS_PROMETHEUS`.

### Companion fix: Prometheus `cluster` external label

The dotdc K8s dashboards (15757 / 15759) filter on a `$cluster` template variable backed by `label_values(cluster)`. Without a `cluster` label on the metrics the dropdown is empty and every panel reads "No data". Adding `prometheus.prometheusSpec.externalLabels.cluster: may-chang` in `helmrelease-kube-prometheus-stack.yaml` makes the variable bind cleanly. Side benefit: multi-cluster Prometheus federations (if you add one later) rely on this exact label to disambiguate sources.

## Test plan

- [x] `kubectl kustomize clusters/may-chang/observability/` renders Prometheus with `externalLabels: { cluster: may-chang }`
- [x] `kubectl kustomize clusters/may-chang/observability-resources/` renders 1 new GrafanaFolder + 3 new GrafanaDashboard CRs
- [ ] After merge: `kubectl -n observability get grafanadashboards` shows `node-exporter-full`, `k8s-views-global`, `k8s-views-nodes` with `NO MATCHING INSTANCES` empty
- [ ] Prometheus pod restarts to pick up new `externalLabels`; `up{cluster="may-chang"}` returns rows in Prometheus
- [ ] Grafana → Dashboards → `Infrastructure` folder shows all three; panels render with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)