### PR TITLE
UTR-000172 fix Prometheus & Tempo datasource URLs

### DIFF
--- a/clusters/may-chang/observability-resources/grafana-datasources.yaml
+++ b/clusters/may-chang/observability-resources/grafana-datasources.yaml
@@ -12,7 +12,9 @@ spec:
     uid: prometheus
     type: prometheus
     access: proxy
-    url: http://kps-kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+    # Service name reflects `fullnameOverride: kps` on the kube-prometheus-stack
+    # HelmRelease — bare chart fullname would be `kube-prometheus-stack-prometheus`.
+    url: http://kps-prometheus.observability.svc.cluster.local:9090
     isDefault: true
     editable: false
     jsonData:
@@ -57,7 +59,8 @@ spec:
     uid: tempo
     type: tempo
     access: proxy
-    url: http://tempo.observability.svc.cluster.local:3100
+    # Port 3200 is Tempo's HTTP query API. 3100 was a copy-paste from Loki.
+    url: http://tempo.observability.svc.cluster.local:3200
     editable: false
     jsonData:
       tracesToLogsV2:

--- a/clusters/may-chang/observability/helmrelease-tempo.yaml
+++ b/clusters/may-chang/observability/helmrelease-tempo.yaml
@@ -59,7 +59,7 @@ spec:
       # remote-written to Prometheus.
       metricsGenerator:
         enabled: true
-        remoteWriteUrl: "http://kps-kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/write"
+        remoteWriteUrl: "http://kps-prometheus.observability.svc.cluster.local:9090/api/v1/write"
 
       storage:
         trace:


### PR DESCRIPTION
## Summary

Every dashboard (utro + infrastructure) was failing with:

```
Post "http://kps-kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090/api/v1/query_range":
dial tcp: lookup kps-kube-prometheus-stack-prometheus.observability.svc.cluster.local: no such host
```

Two URL bugs:

1. **Prometheus**: the kube-prometheus-stack HelmRelease has `fullnameOverride: kps`, so the actual Service is `kps-prometheus` — not `kps-kube-prometheus-stack-prometheus` (chart fullname with release prefix). My original datasource URL guessed the longer name. Fix to `http://kps-prometheus.observability.svc.cluster.local:9090`.
2. **Tempo**: datasource URL was port `3100` (Loki's HTTP port, accidentally copy-pasted). Tempo's HTTP query API is on `3200`. Fix.

Same Prometheus URL bug was also baked into `helmrelease-tempo.yaml` for the metricsGenerator's `remoteWriteUrl`, which is why `traces_service_graph_request_*` metrics never reached Prometheus and the Utro Traces dashboard's service-graph + edge-latency panels stayed empty. Fixing that too.

## Verified by

```
$ kubectl get svc -n observability | grep prom
kps-prometheus                                   ClusterIP 10.43.162.208  9090/TCP,8080/TCP
$ kubectl get svc tempo -n observability -o jsonpath='{.spec.ports[?(@.name=="tempo-prom-metrics")]}'
$ kubectl get svc tempo -n observability  # ports include 3200/TCP
```

## Test plan

- [ ] After merge: `kubectl get grafanadatasource prometheus -n observability -o jsonpath='{.spec.datasource.url}'` returns the corrected URL
- [ ] Open any dashboard (utro or infra) → no "no such host" error
- [ ] Utro Services dashboard renders RPC metrics
- [ ] Node Exporter Full / K8s Views render with data
- [ ] Tempo HelmRelease re-rolls and `traces_service_graph_request_*` start appearing in Prometheus (Utro Traces dashboard's service-map / edge-latency panels populate as new traces arrive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)