### PR TITLE
UTR-000172 enable Prometheus remote-write receiver for Tempo metrics

### DIFF
--- a/clusters/may-chang/observability/helmrelease-kube-prometheus-stack.yaml
+++ b/clusters/may-chang/observability/helmrelease-kube-prometheus-stack.yaml
@@ -47,10 +47,13 @@ spec:
         serviceMonitorNamespaceSelector: {}
         podMonitorNamespaceSelector: {}
         ruleNamespaceSelector: {}
-        # Remote write from Tempo's metrics-generator (service graph + span metrics)
-        # is done by Tempo *pushing* to Prometheus, so we need remote-write-receiver.
-        enableFeatures:
-          - remote-write-receiver
+        # Remote write from Tempo's metrics-generator (service graph + span
+        # metrics) — Tempo pushes to Prometheus via /api/v1/write. The
+        # prometheus-operator field below maps to the `--web.enable-remote-write-receiver`
+        # CLI flag; `enableFeatures: [remote-write-receiver]` does NOT (it's
+        # a separate Prometheus feature-flag mechanism and doesn't enable the
+        # HTTP receiver endpoint).
+        enableRemoteWriteReceiver: true
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
## Summary

The Utro End-to-End Traces dashboard's Service map / Edge latency / Edge request-rate panels are all still empty because Tempo's metrics-generator output isn't landing in Prometheus. Tempo logs:

```
level=ERROR url=http://kps-prometheus.observability.svc.cluster.local:9090/api/v1/write
  failedSampleCount=941
  err="server returned HTTP status 404 Not Found:
       remote write receiver needs to be enabled with --web.enable-remote-write-receiver"
```

My earlier helmrelease set `prometheusSpec.enableFeatures: [remote-write-receiver]` — but that's a *separate* Prometheus experimental-feature mechanism and doesn't enable the HTTP receiver endpoint at all. The right field is `prometheusSpec.enableRemoteWriteReceiver: true`, which the prometheus-operator maps to the actual `--web.enable-remote-write-receiver` CLI flag.

## Test plan

- [ ] After merge: `kubectl -n observability get prometheus -o jsonpath='{.items[*].spec.enableRemoteWriteReceiver}'` returns `true`
- [ ] Prometheus pod rolls and the flag appears in its args: `kubectl -n observability get pod prometheus-kps-prometheus-0 -o jsonpath='{.spec.containers[?(@.name=="prometheus")].args}' | grep enable-remote-write-receiver`
- [ ] Tempo logs stop showing the 404 errors
- [ ] `traces_service_graph_request_*` and `traces_spanmetrics_*` series appear in Prometheus: `kubectl run --rm -it --image=curlimages/curl curl-x -n observability --restart=Never -- sh -c 'curl -s "http://kps-prometheus.observability.svc.cluster.local:9090/api/v1/label/__name__/values" | grep -oE "traces_service_graph[a-z_]*"'`
- [ ] Utro End-to-End Traces dashboard: Service map, Edge latency p95, Edge request rate panels populate within a few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)