### PR TITLE
UTR-000172 enable DB_TRACE on utro statefulsets

### DIFF
--- a/clusters/may-chang/utro/core-statefulset.yaml
+++ b/clusters/may-chang/utro/core-statefulset.yaml
@@ -49,6 +49,8 @@ spec:
           value: "tempo.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
+        - name: DB_TRACE
+          value: "true"
         - name: DB_SSL
           value: "true"
         - name: DB_NAME

--- a/clusters/may-chang/utro/gateway-statefulset.yaml
+++ b/clusters/may-chang/utro/gateway-statefulset.yaml
@@ -55,6 +55,8 @@ spec:
           value: "tempo.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
+        - name: DB_TRACE
+          value: "true"
         - name: DB_SSL
           value: "true"
         - name: DB_NAME

--- a/clusters/may-chang/utro/payment-statefulset.yaml
+++ b/clusters/may-chang/utro/payment-statefulset.yaml
@@ -45,6 +45,8 @@ spec:
           value: "tempo.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
+        - name: DB_TRACE
+          value: "true"
         - name: DB_SSL
           value: "true"
         - name: DB_NAME


### PR DESCRIPTION
## Summary

The **Utro / Database Queries** dashboard is empty because no CLIENT-kind spans for DB queries are reaching Tempo. Verified:

```
$ curl …/api/v1/series?match[]=traces_spanmetrics_calls_total{service="rpg.core",span_kind="SPAN_KIND_CLIENT"}
0 series
```

Root cause: `pkg/database/postgres/connection.go` gates the bun OTel hook behind `config.Trace`:

```go
if config.Trace {
    bunDB.AddQueryHook(tracing.NewBunQueryHook("ump-postgres", false))
}
```

`config.Trace` is bound to the `DB_TRACE` env var (default `false`). None of the three Utro StatefulSets set it, so the hook is never registered, no DB spans are produced, no `traces_spanmetrics_*` series, dashboard empty.

Add `DB_TRACE=true` to core, gateway, and payment StatefulSets.

## Caveat

The `utro` Flux Kustomization is currently `SUSPENDED: true` with image-update controllers stuck `InProgress`. Merging this PR alone won't roll the pods. After merge, also:

```
flux resume kustomization utro          # if SUSPENDED is manual
flux reconcile kustomization utro --with-source
```

If the image-update timeouts return, that's a separate issue (pre-existing) — we can dig into it next.

## Test plan

- [ ] After merge + utro Kustomization reconciles: `kubectl -n default get pod utro-core-0 -o jsonpath='{.spec.containers[0].env[?(@.name=="DB_TRACE")]}'` returns `{name: DB_TRACE, value: "true"}`
- [ ] Pods roll
- [ ] Tempo metrics-generator emits `traces_spanmetrics_calls_total{service="rpg.core",span_kind="SPAN_KIND_CLIENT"}` series
- [ ] Tempo TraceQL `{ span.db.system = "postgresql" }` returns recent traces
- [ ] Utro / Database Queries dashboard's three panels (slowest, rate, p95) all populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)