### PR TITLE
UTR-000172 deploy OTel Collector to route app metrics to Prometheus

### DIFF
--- a/clusters/may-chang/observability/helmrelease-otel-collector.yaml
+++ b/clusters/may-chang/observability/helmrelease-otel-collector.yaml
@@ -1,0 +1,118 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: otel-collector
+  namespace: observability
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      version: "0.153.0"
+      sourceRef:
+        kind: HelmRepository
+        name: open-telemetry
+        namespace: flux-system
+  install:
+    timeout: 10m
+  upgrade:
+    timeout: 10m
+  values:
+    fullnameOverride: otel-collector
+    mode: deployment
+    replicaCount: 1
+
+    # Use the contrib distribution — needed for `prometheusremotewrite`
+    # exporter (which is not in the core image).
+    image:
+      repository: otel/opentelemetry-collector-contrib
+
+    # Disable the chart's "preset" pipelines — we author the full config
+    # ourselves below.
+    presets:
+      logsCollection:
+        enabled: false
+      kubernetesAttributes:
+        enabled: false
+      hostMetrics:
+        enabled: false
+
+    ports:
+      otlp:
+        enabled: true
+        containerPort: 4317
+        servicePort: 4317
+        protocol: TCP
+      otlp-http:
+        enabled: true
+        containerPort: 4318
+        servicePort: 4318
+        protocol: TCP
+      # Disable the default Jaeger / Zipkin ports we don't use.
+      jaeger-compact:
+        enabled: false
+      jaeger-thrift:
+        enabled: false
+      jaeger-grpc:
+        enabled: false
+      zipkin:
+        enabled: false
+      metrics:
+        enabled: false
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+    serviceMonitor:
+      enabled: true
+
+    # Fan-out router: utro apps push OTLP, traces go to Tempo, metrics go
+    # to Prometheus via remote_write. Logs are dropped — Loki gets app
+    # logs via Promtail scraping stdout.
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 1024
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 80
+          spike_limit_percentage: 25
+
+      exporters:
+        otlp/tempo:
+          endpoint: tempo.observability.svc.cluster.local:4317
+          tls:
+            insecure: true
+        prometheusremotewrite:
+          endpoint: http://kps-prometheus.observability.svc.cluster.local:9090/api/v1/write
+          # Pass resource attributes (service.name, service.env, etc.) as
+          # labels so dashboards can filter by service_name.
+          resource_to_telemetry_conversion:
+            enabled: true
+
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [otlp/tempo]
+          metrics:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [prometheusremotewrite]
+        telemetry:
+          logs:
+            level: info

--- a/clusters/may-chang/observability/helmrepo-opentelemetry.yaml
+++ b/clusters/may-chang/observability/helmrepo-opentelemetry.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: open-telemetry
+  namespace: flux-system
+spec:
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts
+  interval: 60m

--- a/clusters/may-chang/observability/kustomization.yaml
+++ b/clusters/may-chang/observability/kustomization.yaml
@@ -29,12 +29,18 @@ resources:
   - helmrepo-prometheus-community.yaml
   - helmrepo-grafana.yaml
   - helmrepo-grafana-operator.yaml
+  - helmrepo-opentelemetry.yaml
   # Helm releases
   - helmrelease-kube-prometheus-stack.yaml
   - helmrelease-loki.yaml
   - helmrelease-promtail.yaml
   - helmrelease-tempo.yaml
   - helmrelease-grafana-operator.yaml
+  # OTel Collector fans out app-pushed OTLP into traces→Tempo and
+  # metrics→Prometheus remote_write. Tempo's OTLP endpoint only handles
+  # traces (returns 404 on /v1/metrics) so apps that emit both must push
+  # to the collector, not directly to Tempo.
+  - helmrelease-otel-collector.yaml
   # The Tailscale exposure (nginx-proxy + cert-sync CronJob) lives in
   # clusters/may-chang/observability-resources/ alongside the Grafana CR.
   # nginx's upstream is the Service created by the operator from the Grafana

--- a/clusters/may-chang/utro/core-statefulset.yaml
+++ b/clusters/may-chang/utro/core-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT
-          value: "tempo.observability.svc.cluster.local:4318"
+          value: "otel-collector.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
         - name: DB_TRACE

--- a/clusters/may-chang/utro/gateway-statefulset.yaml
+++ b/clusters/may-chang/utro/gateway-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT
-          value: "tempo.observability.svc.cluster.local:4318"
+          value: "otel-collector.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
         - name: DB_TRACE

--- a/clusters/may-chang/utro/payment-statefulset.yaml
+++ b/clusters/may-chang/utro/payment-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT
-          value: "tempo.observability.svc.cluster.local:4318"
+          value: "otel-collector.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
         - name: DB_TRACE


### PR DESCRIPTION
## Summary

The **Utro / Database Pool** dashboard was empty because the metrics it needs (`db_pool_connections_*`, `db_pool_acquire_wait_*`) never reach Prometheus. The Utro apps DO emit them — `pkg/database/postgres/pool_metrics.go` registers `db.pool.connections.{open,in_use,idle}` and `db.pool.acquire.{wait_count,wait_seconds}` as OTel observable gauges/counters — but the OTLP metrics exporter is pointed at `tempo.observability.svc.cluster.local:4318`, and Tempo only accepts traces. The app logs show the consequence:

```
failed to upload metrics: failed to send metrics to
http://tempo.observability.svc.cluster.local:4318/v1/metrics: 404 Not Found
```

every 15 seconds, per service.

## Fix

Deploy `open-telemetry/opentelemetry-collector` (contrib distribution) as a fan-out router in the `observability` namespace:

```
utro apps  ──OTLP:4318──▶  otel-collector
                          ├── traces   → tempo:4317
                          └── metrics  → kps-prometheus /api/v1/write
```

Repoint `TR_ENDPOINT` on the three Utro StatefulSets from `tempo.observability…` to `otel-collector.observability…`. Same architecture as the bundled `grafana/otel-lgtm` image used in local dev — single endpoint for the app, collector splits by signal type.

Contrib distribution is required because the `prometheusremotewrite` exporter isn't in the core collector image.

## Test plan

- [x] `kubectl kustomize clusters/may-chang/observability/` renders the new HelmRelease + HelmRepository
- [x] `kubectl kustomize clusters/may-chang/utro/` renders all 3 StatefulSets with the new endpoint
- [ ] After merge: `kubectl -n observability get pod -l app.kubernetes.io/name=opentelemetry-collector` shows Running
- [ ] Utro apps stop logging 404s on `/v1/metrics`
- [ ] `db_pool_connections_open` (and friends) show up in Prometheus: `kubectl run --rm -it --image=curlimages/curl curl-x -n observability --restart=Never -- sh -c 'curl -gs "http://kps-prometheus.observability.svc.cluster.local:9090/api/v1/query?query=db_pool_connections_open"'`
- [ ] Utro / Database Pool dashboard renders gauges + rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)