### PR TITLE
feat(utr-staging): add dedicated postgres cluster (part 1/3, db only)

### DIFF
--- a/clusters/may-chang/flux-system/kustomization.yaml
+++ b/clusters/may-chang/flux-system/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - nginx-ingress-kustomization.yaml
 - pg-operator-kustomization.yaml
 - utro-kustomization.yaml
+- utr-staging-kustomization.yaml
 - n8n-kustomization.yaml
 - tailscale-operator-kustomization.yaml
 - mattermost-operator-kustomization.yaml

--- a/clusters/may-chang/flux-system/utr-staging-kustomization.yaml
+++ b/clusters/may-chang/flux-system/utr-staging-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: utr-staging
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: pg-operator
+      namespace: flux-system
+    - name: external-secrets-resources
+      namespace: flux-system
+  interval: 10m
+  path: ./clusters/may-chang/utr-staging
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true

--- a/clusters/may-chang/pg-operator/cluster.yaml
+++ b/clusters/may-chang/pg-operator/cluster.yaml
@@ -65,11 +65,9 @@ spec:
   users:
     n8n_user: [CREATEROLE]
     utro_user: [CREATEROLE]
-    utr_staging_user: [CREATEROLE]
     mattermost_user: [CREATEROLE]
 
   databases:
     n8n: n8n_user
     utro: utro_user
-    utr_staging: utr_staging_user
     mattermost: mattermost_user

--- a/clusters/may-chang/utr-staging/db-cluster.yaml
+++ b/clusters/may-chang/utr-staging/db-cluster.yaml
@@ -1,0 +1,44 @@
+apiVersion: acid.zalan.do/v1
+kind: postgresql
+metadata:
+  name: pg-staging-cluster
+  namespace: default
+spec:
+  teamId: "inspiration-particle"
+  numberOfInstances: 1
+
+  postgresql:
+    version: "15"
+    parameters:
+      shared_preload_libraries: "pg_cron"
+      cron.database_name: "utr_staging"
+
+  patroni:
+    pg_hba:
+      # local (unix socket)
+      - "local   all             postgres                                md5"
+      - "local   all             utr_staging_user                        md5"
+
+      # ANY host, no-SSL explicitly allowed (matches: no encryption)
+      - "hostnossl all           postgres         0.0.0.0/0              md5"
+      - "hostnossl all           utr_staging_user 0.0.0.0/0              md5"
+      - "hostnossl all           postgres         ::/0                   md5"
+      - "hostnossl all           utr_staging_user ::/0                   md5"
+
+      # ANY host, SSL also allowed
+      - "hostssl all            postgres         0.0.0.0/0              md5"
+      - "hostssl all            utr_staging_user 0.0.0.0/0              md5"
+      - "hostssl all            postgres         ::/0                   md5"
+      - "hostssl all            utr_staging_user ::/0                   md5"
+
+  volume:
+    size: 10Gi
+
+  # No enableLogicalBackup and no WAL_S3_BUCKET env: this cluster is
+  # intentionally excluded from S3 backups (staging data).
+
+  users:
+    utr_staging_user: [CREATEROLE]
+
+  databases:
+    utr_staging: utr_staging_user

--- a/clusters/may-chang/utr-staging/kustomization.yaml
+++ b/clusters/may-chang/utr-staging/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Part 1: database only. App workloads (core/payment/gateway/ui, services,
+  # migrate jobs) and edge (cloudflare tunnel, ingress, image automation) are
+  # added in parts 2 and 3.
+  - db-cluster.yaml


### PR DESCRIPTION
Create a standalone 10Gi postgres cluster (pg-staging-cluster) for the utr-staging environment, deliberately without logical or WAL/S3 backups so staging data is excluded from the prod backup bucket. Wire it into Flux via a dedicated utr-staging Kustomization (dependsOn pg-operator), isolated from the root build so an incomplete staging dir can't halt cluster-wide reconciliation.

The utr-staging kustomization references only db-cluster.yaml for now; app workloads (part 2) and edge/cloudflare+ingress (part 3) follow in later releases.

Also drop the utr_staging db/user from the prod pg-op-cluster CR -- the hyphenated name was rejected by the operator and staging now has its own cluster. Note: the operator does not drop the already-created orphan db/role on prod; that requires a manual DROP.