### PR TITLE
fix(utr-staging): point pg_cron at postgres db to unblock bootstrap

### DIFF
--- a/clusters/may-chang/utr-staging/db-cluster.yaml
+++ b/clusters/may-chang/utr-staging/db-cluster.yaml
@@ -11,7 +11,11 @@ spec:
     version: "15"
     parameters:
       shared_preload_libraries: "pg_cron"
-      cron.database_name: "utr_staging"
+      # pg_cron must live in a database that exists at bootstrap time. On a fresh
+      # cluster the app database (utr_staging) does not exist yet when Spilo's
+      # post_init runs CREATE EXTENSION, so pointing cron here aborts bootstrap.
+      # Use "postgres" (matches how pg-op-cluster actually ended up).
+      cron.database_name: "postgres"
 
   patroni:
     pg_hba:


### PR DESCRIPTION
A fresh cluster cannot CREATE EXTENSION pg_cron in the app database during Spilo post_init -- utr_staging does not exist until after Postgres is up, so post_init exits 3 and Patroni aborts the bootstrap in a crash loop. Point cron.database_name at "postgres" (which exists at bootstrap), matching where pg-op-cluster's pg_cron extension actually lives.