### PR TITLE
fix(utr-staging): drop shared_preload_libraries override to fix boots…

### DIFF
--- a/clusters/may-chang/utr-staging/db-cluster.yaml
+++ b/clusters/may-chang/utr-staging/db-cluster.yaml
@@ -9,13 +9,13 @@ spec:
 
   postgresql:
     version: "15"
-    parameters:
-      shared_preload_libraries: "pg_cron"
-      # pg_cron must live in a database that exists at bootstrap time. On a fresh
-      # cluster the app database (utr_staging) does not exist yet when Spilo's
-      # post_init runs CREATE EXTENSION, so pointing cron here aborts bootstrap.
-      # Use "postgres" (matches how pg-op-cluster actually ended up).
-      cron.database_name: "postgres"
+    # No shared_preload_libraries override. Spilo's default preload list already
+    # includes pg_cron (alongside bg_mon, pg_stat_statements, set_user,
+    # pg_auth_mon, pg_stat_kcache, ...). Overriding it to just "pg_cron" strips
+    # those other modules, and Spilo's post_init bootstrap script then fails to
+    # CREATE EXTENSION for them ("can only be loaded via shared_preload_libraries"),
+    # aborting bootstrap on a fresh cluster. Leaving the default lets it init
+    # cleanly with pg_cron still available.
 
   patroni:
     pg_hba:


### PR DESCRIPTION
…trap

Setting shared_preload_libraries: "pg_cron" replaces Spilo's default preload list rather than extending it, stripping bg_mon, pg_stat_statements, set_user, pg_auth_mon and pg_stat_kcache. Spilo's post_init bootstrap script then fails to CREATE EXTENSION for one of those ("can only be loaded via shared_preload_libraries") and aborts the bootstrap in a crash loop.

Drop the parameters override entirely. Spilo's default preload list already includes pg_cron, so the cluster initializes cleanly and pg_cron stays available -- matching pg-op-cluster, which only survived because the override was applied to an already-bootstrapped cluster (a runtime change never re-runs post_init).