### PR TITLE
feat(utr-staging): match prod pg_cron config and add core migration job

### DIFF
--- a/clusters/may-chang/utr-staging/core-migrate-job.yaml
+++ b/clusters/may-chang/utr-staging/core-migrate-job.yaml
@@ -1,0 +1,68 @@
+# One-shot DB migration Job for the core service.
+#
+# Mirrors the CI behaviour from utro/tools/e2e-test/docker-compose.yml's
+# `migrate` service: same image as the running container, with `MIGRATE=true`
+# in the env. The binary's main() reads MIGRATE, runs goose against
+# app/core/db/*.sql, then exits — no API server is started.
+#
+# Production runs migrations only — no bootstrap step (bootstrap is the
+# CI-only seed-data path).
+#
+# Re-runs every time the image tag changes:
+#   - Image ref carries the same `$imagepolicy` annotation as the StatefulSet,
+#     so Flux's image-update-automation rewrites it whenever a newer tag
+#     matches the ImagePolicy.
+#   - `kustomize.toolkit.fluxcd.io/force: enabled` annotation tells the Flux
+#     kustomize-controller to delete-and-recreate this Job when its template
+#     changes (Job pod template fields are immutable, so a plain apply would
+#     fail otherwise).
+#   - Goose acquires an advisory lock per-DB before running, so concurrent
+#     starts during a rolling restart are safe.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: utr-staging-core-migrate
+  namespace: default
+  labels:
+    app: utr-staging-core-migrate
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  # Auto-clean 24h after success so `kubectl get jobs` doesn't fill up over
+  # time. Failures stick around so they're visible for triage.
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: utr-staging-core-migrate
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: migrate
+        image: ghcr.io/inspiration-particle/utro-core:0.1.20 # {"$imagepolicy": "flux-system:utr-staging-core"}
+        env:
+        - name: MIGRATE
+          value: "true"
+        - name: TIMEZONE
+          value: "Europe/Warsaw"
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: DB_SSL
+          value: "true"
+        - name: DB_NAME
+          value: "utr_staging"
+        - name: DB_HOST
+          value: "pg-staging-cluster.default.svc.cluster.local"
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: username
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: password

--- a/clusters/may-chang/utr-staging/db-cluster.yaml
+++ b/clusters/may-chang/utr-staging/db-cluster.yaml
@@ -9,13 +9,9 @@ spec:
 
   postgresql:
     version: "15"
-    # No shared_preload_libraries override. Spilo's default preload list already
-    # includes pg_cron (alongside bg_mon, pg_stat_statements, set_user,
-    # pg_auth_mon, pg_stat_kcache, ...). Overriding it to just "pg_cron" strips
-    # those other modules, and Spilo's post_init bootstrap script then fails to
-    # CREATE EXTENSION for them ("can only be loaded via shared_preload_libraries"),
-    # aborting bootstrap on a fresh cluster. Leaving the default lets it init
-    # cleanly with pg_cron still available.
+    parameters:
+      shared_preload_libraries: "pg_cron"
+      cron.database_name: "utr_staging"
 
   patroni:
     pg_hba:

--- a/clusters/may-chang/utr-staging/kustomization.yaml
+++ b/clusters/may-chang/utr-staging/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Part 1: database only. App workloads (core/payment/gateway/ui, services,
-  # migrate jobs) and edge (cloudflare tunnel, ingress, image automation) are
-  # added in parts 2 and 3.
   - db-cluster.yaml
+  - core-migrate-job.yaml


### PR DESCRIPTION
Set shared_preload_libraries and cron.database_name on pg-staging-cluster to match pg-op-cluster (prod). The cluster is already bootstrapped so the parameter change is applied to the running instance via Patroni -- the bootstrap chicken-and-egg no longer applies.

Add core-migrate-job.yaml to the utr-staging kustomization so Flux runs the schema migration against the staging database.