### PR TITLE
feat(utr-staging): add core statefulset and service

### DIFF
--- a/clusters/may-chang/utr-staging/core-service.yaml
+++ b/clusters/may-chang/utr-staging/core-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: utr-staging-core
+  namespace: default
+  labels:
+    app: utr-staging-core
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9102
+    targetPort: 9102
+    protocol: TCP
+    name: api
+  - port: 18007
+    targetPort: 18007
+    protocol: TCP
+    name: health
+  selector:
+    app: utr-staging-core

--- a/clusters/may-chang/utr-staging/core-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/core-statefulset.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: utr-staging-core
+  namespace: default
+  labels:
+    app: utr-staging-core
+spec:
+  serviceName: utr-staging-core
+  replicas: 2
+  selector:
+    matchLabels:
+      app: utr-staging-core
+  template:
+    metadata:
+      labels:
+        app: utr-staging-core
+    spec:
+      containers:
+      - name: core
+        image: ghcr.io/inspiration-particle/utro-core:0.1.20 # {"$imagepolicy": "flux-system:utr-staging-core"}
+        ports:
+        - containerPort: 9102
+          name: api
+        - containerPort: 18007
+          name: health
+        env:
+        - name: TIMEZONE
+          value: "Europe/Warsaw"
+        - name: PAYMENT_SERVICE_URL
+          value: "http://utr-staging-payment.default.svc.cluster.local:9102"
+        - name: PAYMENT_SERVICE_CLIENT_TIMEOUT_MS
+          value: "10000"
+        - name: HEALTH_PORT
+          value: "18007"
+        - name: API_PORT
+          value: "9102"
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: RPG_PERMISSIONS_FLAG
+          value: "true"
+        - name: SERVICE_NAME
+          value: "rpg.core"
+        - name: SERVICE_ENV
+          value: "prod"
+        - name: TR_ENABLED
+          value: "true"
+        - name: TR_ENDPOINT
+          value: "otel-collector.observability.svc.cluster.local:4318"
+        - name: TR_HTTPS
+          value: "false"
+        - name: DB_TRACE
+          value: "true"
+        - name: DB_SSL
+          value: "true"
+        - name: DB_NAME
+          value: "utr_staging"
+        - name: DB_HOST
+          value: "pg-staging-cluster.default.svc.cluster.local"
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: username
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: password
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: health
+          initialDelaySeconds: 60
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: health
+          initialDelaySeconds: 60
+          periodSeconds: 5

--- a/clusters/may-chang/utr-staging/kustomization.yaml
+++ b/clusters/may-chang/utr-staging/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - db-cluster.yaml
   - core-migrate-job.yaml
+  - core-statefulset.yaml
+  - core-service.yaml


### PR DESCRIPTION
Add the core service and statefulset to the utr-staging kustomization. Both already point at pg-staging-cluster (DB_NAME=utr_staging, credentials from the operator-generated secret).