### PR TITLE
fix(utr-staging): correct image names to use utro-* registry path

### DIFF
--- a/clusters/may-chang/utr-staging/payment-migrate-job.yaml
+++ b/clusters/may-chang/utr-staging/payment-migrate-job.yaml
@@ -36,7 +36,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: migrate
-        image: ghcr.io/inspiration-particle/utr-staging-payment:0.1.20 # {"$imagepolicy": "flux-system:utr-staging-payment"}
+        image: ghcr.io/inspiration-particle/utro-payment:0.1.20 # {"$imagepolicy": "flux-system:utr-staging-payment"}
         # Bypass the image's `/bin/sh -c /app/payment` ENTRYPOINT so the
         # `-migrate=true` flag reaches the Go binary directly.
         command: ["/app/payment"]

--- a/clusters/may-chang/utr-staging/payment-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/payment-statefulset.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: utr-staging-payment
+  namespace: default
+  labels:
+    app: utr-staging-payment
+spec:
+  serviceName: utr-staging-payment
+  replicas: 2
+  selector:
+    matchLabels:
+      app: utr-staging-payment
+  template:
+    metadata:
+      labels:
+        app: utr-staging-payment
+    spec:
+      containers:
+      - name: payment
+        image: ghcr.io/inspiration-particle/utro-payment:0.1.20  # {"$imagepolicy": "flux-system:utr-staging-payment"}
+        ports:
+        - containerPort: 9102
+          name: api
+        - containerPort: 18007
+          name: health
+        env:
+        - name: TIMEZONE
+          value: "Europe/Warsaw"
+        - name: HEALTH_PORT
+          value: "18007"
+        - name: API_PORT
+          value: "9102"
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: RPG_PERMISSIONS_FLAG
+          value: "true"
+        - name: SERVICE_NAME
+          value: "rpg.payment"
+        - name: SERVICE_ENV
+          value: "prod"
+        - name: TR_ENABLED
+          value: "true"
+        - name: TR_ENDPOINT
+          value: "otel-collector.observability.svc.cluster.local:4318"
+        - name: TR_HTTPS
+          value: "false"
+        - name: DB_TRACE
+          value: "true"
+        - name: DB_SSL
+          value: "true"
+        - name: DB_NAME
+          value: "utr_staging"
+        - name: DB_HOST
+          value: "pg-staging-cluster.default.svc.cluster.local"
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: username
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: password
+        - name: STRIPE_PUBLISHABLE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: stripe-publishable-key
+              key: value
+        - name: STRIPE_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: stripe-secret-key
+              key: value
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: health
+          initialDelaySeconds: 60
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: health
+          initialDelaySeconds: 60
+          periodSeconds: 5

--- a/clusters/may-chang/utr-staging/ui-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/ui-statefulset.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: utr-staging-ui
+  namespace: default
+  labels:
+    app: utr-staging-ui
+spec:
+  serviceName: utr-staging-ui
+  replicas: 2
+  selector:
+    matchLabels:
+      app: utr-staging-ui
+  template:
+    metadata:
+      labels:
+        app: utr-staging-ui
+    spec:
+      containers:
+      - name: ui
+        image: ghcr.io/inspiration-particle/utro-ui:0.1.20 # {"$imagepolicy": "flux-system:utr-staging-ui"}
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: TIMEZONE
+          value: "Europe/Warsaw"
+        - name: NODE_ENV
+          value: "production"
+        - name: BFF_URL
+          value: "http://utr-staging-gateway.default.svc.cluster.local:9999"
+#        - name: CORE_URL
+#          value: "http://utr-staging-core.default.svc.cluster.local:9102"
+        - name: PORT
+          value: "3000"
+        - name: NEXT_TELEMETRY_DISABLED
+          value: "1"
+        - name: CF_TEAM_DOMAIN
+          value: inspiration-particle.cloudflareaccess.com
+        - name: CF_JWT_ISSUER
+          value: https://inspiration-particle.cloudflareaccess.com
+        - name: CF_JWT_AUDIENCE
+          value: afe0fdc2ff299a8bdc7c1e5fd42cc98ecb9c965f447abce6c559b5d6d3613865
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /api/ready
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5


### PR DESCRIPTION
The payment-migrate-job, payment-statefulset, and ui-statefulset referenced non-existent utr-staging-* images. Staging uses the same container images as prod (utro-payment, utro-ui) — only the runtime config (DB, env vars) differs.