### PR TITLE
feat(utr-staging): add UI service, image automation, and GHCR pull se…

### DIFF
--- a/clusters/may-chang/external-secrets-operator/resources/ghcr-pull-secret.yaml
+++ b/clusters/may-chang/external-secrets-operator/resources/ghcr-pull-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-pull-secret
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: google-secrets
+  target:
+    name: ghcr-pull-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"edwardelriczeroclaw-spec","password":"{{ .token }}"}}}
+  data:
+    - secretKey: token
+      remoteRef:
+        key: ghcr-pull-token
+        version: latest

--- a/clusters/may-chang/external-secrets-operator/resources/kustomization.yaml
+++ b/clusters/may-chang/external-secrets-operator/resources/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - letsencrypt-http-private-key.yaml
   - stripe-publishable-key-secret.yaml
   - stripe-secret-key-secret.yaml
+  - ghcr-pull-secret.yaml

--- a/clusters/may-chang/utr-staging/image-policies.yaml
+++ b/clusters/may-chang/utr-staging/image-policies.yaml
@@ -1,0 +1,62 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: utr-staging-core
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: utr-staging-core
+  filterTags:
+    # GHCR release tags emitted by tools/release/release.sh are bare semver
+    # (no `v` prefix), e.g. `0.1.1`. The optional `v?` keeps backwards
+    # compat with any leftover Docker Hub tags that did include it.
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: utr-staging-gateway
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: utr-staging-gateway
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: utr-staging-ui
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: utr-staging-ui
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: utr-staging-payment
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: utr-staging-payment
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/clusters/may-chang/utr-staging/image-repositories.yaml
+++ b/clusters/may-chang/utr-staging/image-repositories.yaml
@@ -1,0 +1,46 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: utr-staging-core
+  namespace: flux-system
+spec:
+  image: ghcr.io/inspiration-particle/utro-core
+  interval: 5m0s
+  # GHCR private packages — Flux needs k8s-side creds to list tags. The
+  # node-level containerd auth (NixOS-managed registries.yaml) handles pod
+  # pulls, but it isn't visible to the Flux source-controller pod.
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: utr-staging-gateway
+  namespace: flux-system
+spec:
+  image: ghcr.io/inspiration-particle/utro-gateway
+  interval: 5m0s
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: utr-staging-ui
+  namespace: flux-system
+spec:
+  image: ghcr.io/inspiration-particle/utro-ui
+  interval: 5m0s
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: utr-staging-payment
+  namespace: flux-system
+spec:
+  image: ghcr.io/inspiration-particle/utro-payment
+  interval: 5m0s
+  secretRef:
+    name: ghcr-pull-secret

--- a/clusters/may-chang/utr-staging/image-update-automation.yaml
+++ b/clusters/may-chang/utr-staging/image-update-automation.yaml
@@ -1,0 +1,42 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: utr-staging-automation
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update
+        
+        Automation name: {{ .AutomationObject }}
+        
+        Files:
+        {{ range $filename, $_ := .Changed.Files -}}
+        - {{ $filename }}
+        {{ end -}}
+        
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+        
+        Images:
+        {{ range .Changed.Images -}}
+        - {{.}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./clusters/may-chang/utr-staging
+    strategy: Setters

--- a/clusters/may-chang/utr-staging/kustomization.yaml
+++ b/clusters/may-chang/utr-staging/kustomization.yaml
@@ -10,3 +10,8 @@ resources:
   - payment-service.yaml
   - gateway-statefulset.yaml
   - gateway-service.yaml
+  - ui-service.yaml
+  - ui-statefulset.yaml
+  - image-repositories.yaml
+  - image-policies.yaml
+  - image-update-automation.yaml

--- a/clusters/may-chang/utr-staging/ui-service.yaml
+++ b/clusters/may-chang/utr-staging/ui-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: utr-staging-ui
+  namespace: default
+  labels:
+    app: utr-staging-ui
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    targetPort: 3000
+    protocol: TCP
+    name: http
+  selector:
+    app: utr-staging-ui


### PR DESCRIPTION
…cret

Add ui-service and ui-statefulset to the staging kustomization.

Add image-repositories, image-policies, and image-update-automation for automated image tag updates on the utr-staging manifests. Fixes from the original copies: core image repo pointed at non-existent utr-staging-core (now utro-core), and update automation path pointed at the prod directory (now utr-staging).

Create an ExternalSecret (ghcr-pull-secret) in flux-system namespace that templates the ghcr-pull-token GCP secret into a dockerconfigjson k8s secret for the image-reflector-controller to authenticate against private GHCR packages.