### PR TITLE
fix(utr-staging): update image automation commit template for v1 API

### DIFF
--- a/clusters/may-chang/utr-staging/image-update-automation.yaml
+++ b/clusters/may-chang/utr-staging/image-update-automation.yaml
@@ -22,17 +22,17 @@ spec:
         Automation name: {{ .AutomationObject }}
         
         Files:
-        {{ range $filename, $_ := .Changed.Files -}}
+        {{ range $filename, $_ := .Changed.FileChanges -}}
         - {{ $filename }}
         {{ end -}}
-        
+
         Objects:
-        {{ range $resource, $_ := .Changed.Objects -}}
+        {{ range $resource, $_ := .Changed.ObjectChanges -}}
         - {{ $resource.Kind }} {{ $resource.Name }}
         {{ end -}}
-        
+
         Images:
-        {{ range .Changed.Images -}}
+        {{ range .Changed.ImageChanges -}}
         - {{.}}
         {{ end -}}
     push:


### PR DESCRIPTION
The ImageUpdateAutomation uses apiVersion v1 but the commit message template referenced v1beta2 fields (.Changed.Files, .Changed.Objects, .Changed.Images). In v1 these are .Changed.FileChanges, .Changed.ObjectChanges, and .Changed.ImageChanges respectively.