### PR TITLE
fix(utr-staging): simplify image automation commit template

### DIFF
--- a/clusters/may-chang/utr-staging/image-update-automation.yaml
+++ b/clusters/may-chang/utr-staging/image-update-automation.yaml
@@ -16,25 +16,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: |
-        Automated image update
-        
-        Automation name: {{ .AutomationObject }}
-        
-        Files:
-        {{ range $filename, $_ := .Changed.FileChanges -}}
-        - {{ $filename }}
-        {{ end -}}
-
-        Objects:
-        {{ range $resource, $_ := .Changed.ObjectChanges -}}
-        - {{ $resource.Kind }} {{ $resource.Name }}
-        {{ end -}}
-
-        Images:
-        {{ range .Changed.ImageChanges -}}
-        - {{.}}
-        {{ end -}}
+      messageTemplate: 'Automated image update by {{ .AutomationObject }}'
     push:
       branch: main
   update:


### PR DESCRIPTION
The v1 ImageUpdateAutomation API changed the template context fields from v1beta2. The detailed template with .Changed.FileChanges/.ObjectChanges/ .ImageChanges failed at runtime. Simplify to a single-line message matching what the live-patched working version uses.