### PR TITLE
feat(utr-staging): add notification service and bootstrap API

### DIFF
--- a/clusters/may-chang/utr-staging/bootstrap-service.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: utr-staging-bootstrap
+  namespace: default
+spec:
+  selector:
+    app: utr-staging-bootstrap
+  ports:
+  - port: 8080
+    targetPort: api
+    protocol: TCP
+  type: ClusterIP

--- a/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
@@ -1,56 +1,48 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: utr-staging-gateway
+  name: utr-staging-bootstrap
   namespace: default
   labels:
-    app: utr-staging-gateway
+    app: utr-staging-bootstrap
 spec:
-  serviceName: utr-staging-gateway
-  replicas: 2
+  serviceName: utr-staging-bootstrap
+  replicas: 1
   selector:
     matchLabels:
-      app: utr-staging-gateway
+      app: utr-staging-bootstrap
   template:
     metadata:
       labels:
-        app: utr-staging-gateway
+        app: utr-staging-bootstrap
     spec:
       containers:
-      - name: gateway
-        image: ghcr.io/inspiration-particle/utro-gateway:0.1.35 # {"$imagepolicy": "flux-system:utr-staging-gateway"}
+      - name: bootstrap
+        image: ghcr.io/inspiration-particle/utro-bootstrap:0.1.35 # {"$imagepolicy": "flux-system:utr-staging-bootstrap"}
         ports:
-        - containerPort: 9999
+        - containerPort: 8080
           name: api
-        - containerPort: 18007
+        - containerPort: 18008
           name: health
         env:
         - name: TIMEZONE
           value: "Europe/Warsaw"
         - name: HEALTH_PORT
-          value: "18007"
-        - name: API_PORT
-          value: "9999"
-        - name: USER
-          value: "postgres"
+          value: "18008"
+        - name: BOOTSTRAP_API_PORT
+          value: "8080"
         - name: LOG_LEVEL
           value: "debug"
-        - name: PAYMENT_SERVICE
-          value: "utr-staging-payment.default.svc.cluster.local:9102"
-        - name: NOTIFICATION_SERVICE
+        - name: ENABLE_DEV_API
+          value: "true"
+        - name: CORE_API_URL
+          value: "http://utr-staging-core.default.svc.cluster.local:9102"
+        - name: NOTIFICATION_API_URL
           value: "http://utr-staging-notification.default.svc.cluster.local:9002"
-        - name: CORE_SERVICE
-          value: "utr-staging-core.default.svc.cluster.local:9102"
-        - name: WITH_PERMISSIONS
-          value: "true"
-        - name: ENABLE_PERMISSIONS
-          value: "true"
-        - name: RPG_PERMISSIONS_FLAG
-          value: "true"
         - name: SERVICE_NAME
-          value: "rpg.gateway"
+          value: "rpg-bootstrap"
         - name: SERVICE_ENV
-          value: "prod"
+          value: "staging"
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT

--- a/clusters/may-chang/utr-staging/core-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/core-statefulset.yaml
@@ -49,6 +49,8 @@ spec:
           value: "otel-collector.observability.svc.cluster.local:4318"
         - name: TR_HTTPS
           value: "false"
+        - name: ENABLE_DEV_API
+          value: "true"
         - name: DB_TRACE
           value: "true"
         - name: DB_SSL

--- a/clusters/may-chang/utr-staging/image-policies.yaml
+++ b/clusters/may-chang/utr-staging/image-policies.yaml
@@ -60,3 +60,33 @@ spec:
   policy:
     semver:
       range: '>=0.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: utr-staging-notification
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: utr-staging-notification
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: utr-staging-bootstrap
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: utr-staging-bootstrap
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+'
+    extract: '$0'
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/clusters/may-chang/utr-staging/image-repositories.yaml
+++ b/clusters/may-chang/utr-staging/image-repositories.yaml
@@ -44,3 +44,25 @@ spec:
   interval: 5m0s
   secretRef:
     name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: utr-staging-notification
+  namespace: flux-system
+spec:
+  image: ghcr.io/inspiration-particle/utro-notification
+  interval: 5m0s
+  secretRef:
+    name: ghcr-pull-secret
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: utr-staging-bootstrap
+  namespace: flux-system
+spec:
+  image: ghcr.io/inspiration-particle/utro-bootstrap
+  interval: 5m0s
+  secretRef:
+    name: ghcr-pull-secret

--- a/clusters/may-chang/utr-staging/kustomization.yaml
+++ b/clusters/may-chang/utr-staging/kustomization.yaml
@@ -8,6 +8,11 @@ resources:
   - payment-migrate-job.yaml
   - payment-statefulset.yaml
   - payment-service.yaml
+  - notification-migrate-job.yaml
+  - notification-statefulset.yaml
+  - notification-service.yaml
+  - bootstrap-statefulset.yaml
+  - bootstrap-service.yaml
   - gateway-statefulset.yaml
   - gateway-service.yaml
   - ui-service.yaml

--- a/clusters/may-chang/utr-staging/notification-migrate-job.yaml
+++ b/clusters/may-chang/utr-staging/notification-migrate-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: utr-staging-notification-migrate
+  namespace: default
+  labels:
+    app: utr-staging-notification-migrate
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  ttlSecondsAfterFinished: 86400
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: utr-staging-notification-migrate
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: migrate
+        image: ghcr.io/inspiration-particle/utro-notification:0.1.35 # {"$imagepolicy": "flux-system:utr-staging-notification"}
+        command: ["/app/notification"]
+        args: ["-migrate=true"]
+        env:
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: DB_SSL
+          value: "true"
+        - name: DB_NAME
+          value: "utr_staging"
+        - name: DB_HOST
+          value: "pg-staging-cluster.default.svc.cluster.local"
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: username
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              key: password

--- a/clusters/may-chang/utr-staging/notification-service.yaml
+++ b/clusters/may-chang/utr-staging/notification-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: utr-staging-notification
+  namespace: default
+spec:
+  selector:
+    app: utr-staging-notification
+  ports:
+  - port: 9002
+    targetPort: api
+    protocol: TCP
+  type: ClusterIP

--- a/clusters/may-chang/utr-staging/notification-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/notification-statefulset.yaml
@@ -1,26 +1,26 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: utr-staging-gateway
+  name: utr-staging-notification
   namespace: default
   labels:
-    app: utr-staging-gateway
+    app: utr-staging-notification
 spec:
-  serviceName: utr-staging-gateway
-  replicas: 2
+  serviceName: utr-staging-notification
+  replicas: 1
   selector:
     matchLabels:
-      app: utr-staging-gateway
+      app: utr-staging-notification
   template:
     metadata:
       labels:
-        app: utr-staging-gateway
+        app: utr-staging-notification
     spec:
       containers:
-      - name: gateway
-        image: ghcr.io/inspiration-particle/utro-gateway:0.1.35 # {"$imagepolicy": "flux-system:utr-staging-gateway"}
+      - name: notification
+        image: ghcr.io/inspiration-particle/utro-notification:0.1.35 # {"$imagepolicy": "flux-system:utr-staging-notification"}
         ports:
-        - containerPort: 9999
+        - containerPort: 9002
           name: api
         - containerPort: 18007
           name: health
@@ -30,27 +30,15 @@ spec:
         - name: HEALTH_PORT
           value: "18007"
         - name: API_PORT
-          value: "9999"
-        - name: USER
-          value: "postgres"
+          value: "9002"
         - name: LOG_LEVEL
           value: "debug"
-        - name: PAYMENT_SERVICE
-          value: "utr-staging-payment.default.svc.cluster.local:9102"
-        - name: NOTIFICATION_SERVICE
-          value: "http://utr-staging-notification.default.svc.cluster.local:9002"
-        - name: CORE_SERVICE
-          value: "utr-staging-core.default.svc.cluster.local:9102"
-        - name: WITH_PERMISSIONS
-          value: "true"
-        - name: ENABLE_PERMISSIONS
-          value: "true"
-        - name: RPG_PERMISSIONS_FLAG
-          value: "true"
         - name: SERVICE_NAME
-          value: "rpg.gateway"
+          value: "rpg.notification"
         - name: SERVICE_ENV
-          value: "prod"
+          value: "staging"
+        - name: ENABLE_DEV_API
+          value: "true"
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT


### PR DESCRIPTION
## Summary
- Deploy **notification service** to staging: migration job, statefulset (replica 1, port 9002), ClusterIP service
- Deploy **bootstrap in API mode** (`ENABLE_DEV_API=true`): stays running as HTTP server on port 8080, exposes `ResetDatabase` endpoint that resets core + notification DBs and re-seeds bootstrap data
- Enable `ENABLE_DEV_API` on **core** so bootstrap's reset flow can call `core.dev.v1.DevService/ResetDatabase`
- Wire **gateway → notification** via `NOTIFICATION_SERVICE` env var
- Add **image automation** (ImageRepository + ImagePolicy) for `utro-notification` and `utro-bootstrap`

## Test plan
- [ ] Verify notification migration job completes successfully
- [ ] Verify notification statefulset reaches ready state
- [ ] Verify bootstrap statefulset starts in API mode (stays running, doesn't exit after seed)
- [ ] Verify gateway routes notification RPCs correctly
- [ ] Call `bootstrap:8080/bootstrap.v1.BootstrapService/ResetDatabase` and confirm full reset cycle works
- [ ] Verify image automation picks up new tags for notification and bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)