### PR TITLE
fix(utr-staging): bootstrap probe + notification release

### DIFF
--- a/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
@@ -22,13 +22,9 @@ spec:
         ports:
         - containerPort: 8080
           name: api
-        - containerPort: 18008
-          name: health
         env:
         - name: TIMEZONE
           value: "Europe/Warsaw"
-        - name: HEALTH_PORT
-          value: "18008"
         - name: BOOTSTRAP_API_PORT
           value: "8080"
         - name: LOG_LEVEL
@@ -70,14 +66,12 @@ spec:
               name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
-          httpGet:
-            path: /live
-            port: health
-          initialDelaySeconds: 60
+          tcpSocket:
+            port: api
+          initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
-          httpGet:
-            path: /ready
-            port: health
-          initialDelaySeconds: 60
+          tcpSocket:
+            port: api
+          initialDelaySeconds: 10
           periodSeconds: 5


### PR DESCRIPTION
## Summary
- Switch bootstrap health probes from HTTP `/live`/`/ready` to TCP socket on API port — bootstrap in DEV_API mode doesn't register health server endpoints
- **Note**: `utro-notification:0.1.35` doesn't exist in GHCR — notification was never included in the release script's `SERVICES` array. Companion fix in utro repo adds it to `tools/release/release.sh` and `inherit-from-pr.sh`

## Test plan
- [ ] Bootstrap pod should pass liveness/readiness probes after this fix
- [ ] After utro release script fix + next release, notification image policy should resolve a semver tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)