### PR TITLE
feat(utr-staging): add service versions and fix env labels

### DIFF
--- a/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
@@ -22,9 +22,13 @@ spec:
         ports:
         - containerPort: 8080
           name: api
+        - containerPort: 18008
+          name: health
         env:
         - name: TIMEZONE
           value: "Europe/Warsaw"
+        - name: HEALTH_PORT
+          value: "18008"
         - name: BOOTSTRAP_API_PORT
           value: "8080"
         - name: LOG_LEVEL
@@ -35,6 +39,8 @@ spec:
           value: "http://utr-staging-core.default.svc.cluster.local:9102"
         - name: NOTIFICATION_API_URL
           value: "http://utr-staging-notification.default.svc.cluster.local:9002"
+        - name: SERVICE_VERSION
+          value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-bootstrap:tag"}
         - name: SERVICE_NAME
           value: "rpg-bootstrap"
         - name: SERVICE_ENV
@@ -66,12 +72,14 @@ spec:
               name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
-          tcpSocket:
-            port: api
-          initialDelaySeconds: 30
+          httpGet:
+            path: /live
+            port: health
+          initialDelaySeconds: 60
           periodSeconds: 10
         readinessProbe:
-          tcpSocket:
-            port: api
-          initialDelaySeconds: 10
+          httpGet:
+            path: /ready
+            port: health
+          initialDelaySeconds: 60
           periodSeconds: 5

--- a/clusters/may-chang/utr-staging/core-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/core-statefulset.yaml
@@ -39,10 +39,12 @@ spec:
           value: "debug"
         - name: RPG_PERMISSIONS_FLAG
           value: "true"
+        - name: SERVICE_VERSION
+          value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-core:tag"}
         - name: SERVICE_NAME
           value: "rpg.core"
         - name: SERVICE_ENV
-          value: "prod"
+          value: "staging"
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT

--- a/clusters/may-chang/utr-staging/gateway-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/gateway-statefulset.yaml
@@ -47,10 +47,12 @@ spec:
           value: "true"
         - name: RPG_PERMISSIONS_FLAG
           value: "true"
+        - name: SERVICE_VERSION
+          value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-gateway:tag"}
         - name: SERVICE_NAME
           value: "rpg.gateway"
         - name: SERVICE_ENV
-          value: "prod"
+          value: "staging"
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT

--- a/clusters/may-chang/utr-staging/notification-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/notification-statefulset.yaml
@@ -33,6 +33,8 @@ spec:
           value: "9002"
         - name: LOG_LEVEL
           value: "debug"
+        - name: SERVICE_VERSION
+          value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-notification:tag"}
         - name: SERVICE_NAME
           value: "rpg.notification"
         - name: SERVICE_ENV

--- a/clusters/may-chang/utr-staging/payment-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/payment-statefulset.yaml
@@ -35,10 +35,12 @@ spec:
           value: "debug"
         - name: RPG_PERMISSIONS_FLAG
           value: "true"
+        - name: SERVICE_VERSION
+          value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-payment:tag"}
         - name: SERVICE_NAME
           value: "rpg.payment"
         - name: SERVICE_ENV
-          value: "prod"
+          value: "staging"
         - name: TR_ENABLED
           value: "true"
         - name: TR_ENDPOINT

--- a/clusters/may-chang/utr-staging/ui-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/ui-statefulset.yaml
@@ -31,6 +31,12 @@ spec:
           value: "http://utr-staging-gateway.default.svc.cluster.local:9999"
           #        - name: CORE_URL
           #          value: "http://utr-staging-core.default.svc.cluster.local:9102"
+        - name: APP_ENV
+          value: "staging"
+        - name: APP_VERSION
+          value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-ui:tag"}
+        - name: VERSION_CHECK_URLS
+          value: "core=utr-staging-core:18007,gateway=utr-staging-gateway:18007,payment=utr-staging-payment:18007,notification=utr-staging-notification:18007,bootstrap=utr-staging-bootstrap:18008"
         - name: PORT
           value: "3000"
         - name: NEXT_TELEMETRY_DISABLED

--- a/clusters/may-chang/utr-staging/ui-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/ui-statefulset.yaml
@@ -31,9 +31,9 @@ spec:
           value: "http://utr-staging-gateway.default.svc.cluster.local:9999"
           #        - name: CORE_URL
           #          value: "http://utr-staging-core.default.svc.cluster.local:9102"
-        - name: APP_ENV
+        - name: SERVICE_ENV
           value: "staging"
-        - name: APP_VERSION
+        - name: SERVICE_VERSION
           value: "0.1.37" # {"$imagepolicy": "flux-system:utr-staging-ui:tag"}
         - name: VERSION_CHECK_URLS
           value: "core=utr-staging-core:18007,gateway=utr-staging-gateway:18007,payment=utr-staging-payment:18007,notification=utr-staging-notification:18007,bootstrap=utr-staging-bootstrap:18008"


### PR DESCRIPTION
## Summary
- Add `SERVICE_VERSION` env var to all staging statefulsets with `$imagepolicy:tag` markers — Flux image automation keeps them in sync automatically
- Fix `SERVICE_ENV` from `"prod"` to `"staging"` on core, gateway, payment
- Re-add health port (18008) to bootstrap and switch probes back to HTTP `/live`/`/ready` (companion change in utro repo wires up the health server in API mode)
- Add `APP_VERSION`, `APP_ENV`, and `VERSION_CHECK_URLS` to UI statefulset for the version display feature

## Test plan
- [ ] After utro repo change is deployed, `curl <service>:18007/info` returns name + version
- [ ] UI sidebar shows service versions at the bottom when expanded
- [ ] On next release, image automation bumps both `image:` and `SERVICE_VERSION` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)