### PR TITLE
fix(utr-staging): use postgres superuser for bootstrap

### DIFF
--- a/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
@@ -64,12 +64,12 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: postgres.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: postgres.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- Switch bootstrap statefulset DB credentials from `utr_staging_user` to `postgres` superuser
- Bootstrap needs to bypass RLS to create the initial admin user — same as the e2e docker-compose which uses `DB_USER: postgres`

## Test plan
- [ ] Merge and let Flux apply
- [ ] Hit Reset Database in Dev Tools — should complete without RLS error

🤖 Generated with [Claude Code](https://claude.com/claude-code)