### PR TITLE
feat(utr-staging): add dedicated migrator user with BYPASSRLS

### DIFF
--- a/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-statefulset.yaml
@@ -64,12 +64,12 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: postgres.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: postgres.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
           httpGet:

--- a/clusters/may-chang/utr-staging/core-migrate-job.yaml
+++ b/clusters/may-chang/utr-staging/core-migrate-job.yaml
@@ -59,10 +59,10 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password

--- a/clusters/may-chang/utr-staging/core-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/core-statefulset.yaml
@@ -66,12 +66,12 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
           httpGet:

--- a/clusters/may-chang/utr-staging/db-cluster.yaml
+++ b/clusters/may-chang/utr-staging/db-cluster.yaml
@@ -18,18 +18,23 @@ spec:
       # local (unix socket)
       - "local   all             postgres                                md5"
       - "local   all             utr_staging_user                        md5"
+      - "local   all             utr_staging_migrator                    md5"
 
       # ANY host, no-SSL explicitly allowed (matches: no encryption)
-      - "hostnossl all           postgres         0.0.0.0/0              md5"
-      - "hostnossl all           utr_staging_user 0.0.0.0/0              md5"
-      - "hostnossl all           postgres         ::/0                   md5"
-      - "hostnossl all           utr_staging_user ::/0                   md5"
+      - "hostnossl all           postgres             0.0.0.0/0          md5"
+      - "hostnossl all           utr_staging_user     0.0.0.0/0          md5"
+      - "hostnossl all           utr_staging_migrator 0.0.0.0/0          md5"
+      - "hostnossl all           postgres             ::/0               md5"
+      - "hostnossl all           utr_staging_user     ::/0               md5"
+      - "hostnossl all           utr_staging_migrator ::/0               md5"
 
       # ANY host, SSL also allowed
-      - "hostssl all            postgres         0.0.0.0/0              md5"
-      - "hostssl all            utr_staging_user 0.0.0.0/0              md5"
-      - "hostssl all            postgres         ::/0                   md5"
-      - "hostssl all            utr_staging_user ::/0                   md5"
+      - "hostssl all             postgres             0.0.0.0/0          md5"
+      - "hostssl all             utr_staging_user     0.0.0.0/0          md5"
+      - "hostssl all             utr_staging_migrator 0.0.0.0/0          md5"
+      - "hostssl all             postgres             ::/0               md5"
+      - "hostssl all             utr_staging_user     ::/0               md5"
+      - "hostssl all             utr_staging_migrator ::/0               md5"
 
   volume:
     size: 10Gi
@@ -39,6 +44,7 @@ spec:
 
   users:
     utr_staging_user: [CREATEROLE]
+    utr_staging_migrator: [BYPASSRLS, CREATEROLE]
 
   databases:
-    utr_staging: utr_staging_user
+    utr_staging: utr_staging_migrator

--- a/clusters/may-chang/utr-staging/notification-migrate-job.yaml
+++ b/clusters/may-chang/utr-staging/notification-migrate-job.yaml
@@ -35,10 +35,10 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password

--- a/clusters/may-chang/utr-staging/notification-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/notification-statefulset.yaml
@@ -60,12 +60,12 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
           httpGet:

--- a/clusters/may-chang/utr-staging/payment-migrate-job.yaml
+++ b/clusters/may-chang/utr-staging/payment-migrate-job.yaml
@@ -57,10 +57,10 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password


### PR DESCRIPTION
## Summary
- Add `utr_staging_migrator` role with `[BYPASSRLS, CREATEROLE]` to staging Postgres cluster
- Make it the database owner so migration-created SECURITY DEFINER functions (e.g. `can()`, `can_access()`) are owned by a BYPASSRLS role — prevents infinite RLS recursion
- Migration jobs → migrator credentials
- Core + notification services → migrator (for DevService/ResetDatabase)
- Bootstrap → migrator (for seed data)
- Gateway + payment stay on `utr_staging_user` (app-level, RLS enforced via `SET LOCAL ROLE`)
- pg_hba rules added for the new user

## After merge
Database schemas need to be dropped and migrations re-run so all functions are re-created with the migrator as owner. Use the Dev Tools reset button or manually drop schemas.

## Test plan
- [ ] Operator creates the migrator user and secret
- [ ] Migration jobs complete with migrator credentials
- [ ] Dev Tools reset completes without RLS recursion
- [ ] App operations (gateway, payment) still enforce RLS via utr_staging_user

🤖 Generated with [Claude Code](https://claude.com/claude-code)