### PR TITLE
fix(utr-staging): revert core and notification API to utr_staging_user

### DIFF
--- a/clusters/may-chang/utr-staging/core-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/core-statefulset.yaml
@@ -66,12 +66,12 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
           httpGet:

--- a/clusters/may-chang/utr-staging/notification-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/notification-statefulset.yaml
@@ -60,12 +60,12 @@ spec:
         - name: DB_USER
           valueFrom:
             secretKeyRef:
-              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: username
         - name: DB_PASS
           valueFrom:
             secretKeyRef:
-              name: utr-staging-migrator.pg-staging-cluster.credentials.postgresql.acid.zalan.do
+              name: utr-staging-user.pg-staging-cluster.credentials.postgresql.acid.zalan.do
               key: password
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary

- Revert core and notification **statefulsets** (API services) from `utr-staging-migrator` back to `utr-staging-user` credentials
- These services use `SET LOCAL ROLE rls_enabled_role` per request — they must run as a non-BYPASSRLS user
- Migration **jobs** and bootstrap remain on `utr-staging-migrator` (BYPASSRLS) as intended

## Context

PR #40 had the correct fix but was overwritten by automated image update commits from flux-system/utr-staging-automation. This PR rebases the same change on top of the latest main.

## Test plan

- [ ] Core API responds without 500s after Flux reconciles
- [ ] `SET LOCAL ROLE rls_enabled_role` succeeds (no permission denied)
- [ ] RLS policies enforced on API requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)