### PR TITLE
feat(utr-staging): enable browser OTEL tracing for UI

### DIFF
--- a/clusters/may-chang/utr-staging/ui-statefulset.yaml
+++ b/clusters/may-chang/utr-staging/ui-statefulset.yaml
@@ -43,6 +43,14 @@ spec:
           value: "3000"
         - name: NEXT_TELEMETRY_DISABLED
           value: "1"
+        - name: NEXT_PUBLIC_OTEL_ENABLED
+          value: "true"
+        - name: NEXT_PUBLIC_OTEL_ENDPOINT
+          value: "/otel/v1/traces"
+        - name: NEXT_PUBLIC_SERVICE_ENV
+          value: "staging"
+        - name: OTEL_COLLECTOR_URL
+          value: "http://otel-collector.observability.svc.cluster.local:4318"
         - name: CF_TEAM_DOMAIN
           value: inspiration-particle.cloudflareaccess.com
         - name: CF_JWT_ISSUER


### PR DESCRIPTION
## Summary

- Add OTEL env vars to staging UI statefulset so browser traces flow to the cluster collector
- Traces tagged with `deployment.environment.name=staging` and `service.name=utro-ui`

## Dependency

Requires [utro#155](https://github.com/inspiration-particle/utro/pull/155) to be merged and deployed first (adds the Next.js rewrite proxy).

## Test plan

- [ ] Merge utro#155 first, wait for image to build
- [ ] Merge this PR, Flux reconciles
- [ ] `/otel/v1/traces` requests return 200 in browser network tab
- [ ] Traces visible in Grafana Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)