### PR TITLE
fix(utr-staging): expose health ports on notification and bootstrap services

### DIFF
--- a/clusters/may-chang/utr-staging/bootstrap-service.yaml
+++ b/clusters/may-chang/utr-staging/bootstrap-service.yaml
@@ -10,4 +10,9 @@ spec:
   - port: 8080
     targetPort: api
     protocol: TCP
+    name: api
+  - port: 18008
+    targetPort: 18008
+    protocol: TCP
+    name: health
   type: ClusterIP

--- a/clusters/may-chang/utr-staging/notification-service.yaml
+++ b/clusters/may-chang/utr-staging/notification-service.yaml
@@ -10,4 +10,9 @@ spec:
   - port: 9002
     targetPort: api
     protocol: TCP
+    name: api
+  - port: 18007
+    targetPort: 18007
+    protocol: TCP
+    name: health
   type: ClusterIP


### PR DESCRIPTION
## Summary

- Add health port (18007) to notification Service
- Add health port (18008) to bootstrap Service

The UI version check calls `/info` on these health ports but the Services only exposed the API ports, so they showed as "unknown".

## Test plan

- [ ] Notification and bootstrap show version numbers in the UI info panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)