### PR TITLE
feat(infra): customer Firebase auth — Identity Platform, gateway/ui deploy, Cloudflare routes

### DIFF
--- a/clusters/may-chang/external-secrets-operator/resources/firebase-admin-secret.yaml
+++ b/clusters/may-chang/external-secrets-operator/resources/firebase-admin-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: utro-customer-gateway-firebase-admin
+  namespace: default
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: google-secrets
+    kind: ClusterSecretStore
+  target:
+    name: utro-customer-gateway-firebase-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: credentials.json
+      remoteRef:
+        key: utro-customer-gateway-firebase-admin
+        version: latest

--- a/clusters/may-chang/external-secrets-operator/resources/kustomization.yaml
+++ b/clusters/may-chang/external-secrets-operator/resources/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - clustersecretstore-google-secrets.yaml
+  - firebase-admin-secret.yaml
   - aws-access-key.yaml
   - aws-secret-access-key.yaml
   - letsencrypt-http-private-key.yaml

--- a/clusters/may-chang/utro/customer-gateway-service.yaml
+++ b/clusters/may-chang/utro/customer-gateway-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: utro-customer-gateway
+  namespace: default
+  labels:
+    app: utro-customer-gateway
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9998
+    targetPort: 9998
+    protocol: TCP
+    name: api
+  - port: 18008
+    targetPort: 18008
+    protocol: TCP
+    name: health
+  selector:
+    app: utro-customer-gateway

--- a/clusters/may-chang/utro/customer-gateway-statefulset.yaml
+++ b/clusters/may-chang/utro/customer-gateway-statefulset.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: utro-customer-gateway
+  namespace: default
+  labels:
+    app: utro-customer-gateway
+spec:
+  serviceName: utro-customer-gateway
+  replicas: 2
+  selector:
+    matchLabels:
+      app: utro-customer-gateway
+  template:
+    metadata:
+      labels:
+        app: utro-customer-gateway
+    spec:
+      containers:
+      - name: customer-gateway
+        image: ghcr.io/inspiration-particle/utro-customer-gateway:0.0.1
+        ports:
+        - containerPort: 9998
+          name: api
+        - containerPort: 18008
+          name: health
+        env:
+        - name: TIMEZONE
+          value: "Europe/Warsaw"
+        - name: HEALTH_PORT
+          value: "18008"
+        - name: API_PORT
+          value: "9998"
+        - name: USER
+          value: "postgres"
+        - name: LOG_LEVEL
+          value: "debug"
+        - name: CORE_SERVICE
+          value: "utro-core.default.svc.cluster.local:9102"
+        # Lock CORS to the customer web origin (Bearer auth, so no credentialed cookies).
+        - name: API_CORS
+          value: "https://app.inspiration-particle.com"
+        - name: WITH_PERMISSIONS
+          value: "true"
+        - name: ENABLE_PERMISSIONS
+          value: "true"
+        - name: RPG_PERMISSIONS_FLAG
+          value: "true"
+        - name: SERVICE_NAME
+          value: "rpg.customer-gateway"
+        - name: SERVICE_ENV
+          value: "prod"
+        - name: SERVICE_VERSION
+          value: "0.0.1"
+        # Firebase / Identity Platform. FIREBASE_PROJECT_ID must match the project the
+        # customer ID tokens are issued for (the same project as infra/utro firebase.tf).
+        - name: FIREBASE_PROJECT_ID
+          value: "REPLACE_WITH_GCP_PROJECT_ID"
+        - name: FIREBASE_CHECK_REVOKED
+          value: "true"
+        - name: FIREBASE_CREDENTIALS_FILE
+          value: "/var/secrets/firebase/credentials.json"
+        - name: TR_ENABLED
+          value: "true"
+        - name: TR_ENDPOINT
+          value: "otel-collector.observability.svc.cluster.local:4318"
+        - name: TR_HTTPS
+          value: "false"
+        - name: DB_TRACE
+          value: "true"
+        - name: DB_SSL
+          value: "true"
+        - name: DB_NAME
+          value: "utro"
+        - name: DB_HOST
+          value: "pg-op-cluster.default.svc.cluster.local"
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: utro-user.pg-op-cluster.credentials.postgresql.acid.zalan.do
+              key: username
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: utro-user.pg-op-cluster.credentials.postgresql.acid.zalan.do
+              key: password
+        volumeMounts:
+        - name: firebase-creds
+          mountPath: /var/secrets/firebase
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: health
+          initialDelaySeconds: 60
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: health
+          initialDelaySeconds: 60
+          periodSeconds: 5
+      volumes:
+      - name: firebase-creds
+        secret:
+          secretName: utro-customer-gateway-firebase-admin
+          items:
+          - key: credentials.json
+            path: credentials.json

--- a/clusters/may-chang/utro/customer-ui-service.yaml
+++ b/clusters/may-chang/utro/customer-ui-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: utro-customer-ui
+  namespace: default
+  labels:
+    app: utro-customer-ui
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    targetPort: 3000
+    protocol: TCP
+    name: http
+  selector:
+    app: utro-customer-ui

--- a/clusters/may-chang/utro/customer-ui-statefulset.yaml
+++ b/clusters/may-chang/utro/customer-ui-statefulset.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: utro-customer-ui
+  namespace: default
+  labels:
+    app: utro-customer-ui
+spec:
+  serviceName: utro-customer-ui
+  replicas: 2
+  selector:
+    matchLabels:
+      app: utro-customer-ui
+  template:
+    metadata:
+      labels:
+        app: utro-customer-ui
+    spec:
+      containers:
+      - name: customer-ui
+        # NEXT_PUBLIC_* (customer-gateway URL, Firebase web config) are baked at
+        # build time via CI build-args, not runtime env — see the Dockerfile.
+        image: ghcr.io/inspiration-particle/utro-customer-ui:0.0.1
+        ports:
+        - containerPort: 3000
+          name: http
+        env:
+        - name: TIMEZONE
+          value: "Europe/Warsaw"
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: NEXT_TELEMETRY_DISABLED
+          value: "1"
+        # TCP probes: this is a public app with no /api health route (API routes
+        # are omitted so the same bundle can static-export for Capacitor).
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5

--- a/clusters/may-chang/utro/kustomization.yaml
+++ b/clusters/may-chang/utro/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - gateway-statefulset.yaml
   - gateway-service.yaml
+  - customer-gateway-statefulset.yaml
+  - customer-gateway-service.yaml
+  - customer-ui-statefulset.yaml
+  - customer-ui-service.yaml
   - core-statefulset.yaml
   - core-service.yaml
   - core-migrate-job.yaml

--- a/infra/cloudflare/access.tf
+++ b/infra/cloudflare/access.tf
@@ -42,3 +42,45 @@ resource "cloudflare_zero_trust_access_policy" "production_webhook_bypass" {
     everyone = true
   }
 }
+
+# The customer app and its API are public (customers are not org members). Bypass
+# Cloudflare Access; auth is enforced by Firebase + the customer-gateway, not Access.
+resource "cloudflare_zero_trust_access_application" "customer_app" {
+  zone_id          = local.zone_inspiration_particle
+  name             = "Customer App Bypass"
+  domain           = "app.inspiration-particle.com"
+  type             = "self_hosted"
+  session_duration = "24h"
+}
+
+resource "cloudflare_zero_trust_access_policy" "customer_app_bypass" {
+  zone_id        = local.zone_inspiration_particle
+  application_id = cloudflare_zero_trust_access_application.customer_app.id
+  name           = "Bypass for customers"
+  decision       = "bypass"
+  precedence     = 2
+
+  include {
+    everyone = true
+  }
+}
+
+resource "cloudflare_zero_trust_access_application" "customer_api" {
+  zone_id          = local.zone_inspiration_particle
+  name             = "Customer API Bypass"
+  domain           = "customer-api.inspiration-particle.com"
+  type             = "self_hosted"
+  session_duration = "24h"
+}
+
+resource "cloudflare_zero_trust_access_policy" "customer_api_bypass" {
+  zone_id        = local.zone_inspiration_particle
+  application_id = cloudflare_zero_trust_access_application.customer_api.id
+  name           = "Bypass for customers"
+  decision       = "bypass"
+  precedence     = 3
+
+  include {
+    everyone = true
+  }
+}

--- a/infra/cloudflare/dns.tf
+++ b/infra/cloudflare/dns.tf
@@ -47,6 +47,25 @@ resource "cloudflare_record" "utro_cname" {
   ttl     = 1
 }
 
+# Customer-facing app + its API, both fronted by the utro tunnel.
+resource "cloudflare_record" "customer_app_cname" {
+  zone_id = local.zone_inspiration_particle
+  name    = "app"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.utro.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_record" "customer_api_cname" {
+  zone_id = local.zone_inspiration_particle
+  name    = "customer-api"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.utro.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+}
+
 resource "cloudflare_record" "www_cname" {
   zone_id = local.zone_inspiration_particle
   name    = "www"

--- a/infra/cloudflare/tunnel.tf
+++ b/infra/cloudflare/tunnel.tf
@@ -43,24 +43,51 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "utro" {
       hostname = "utro.inspiration-particle.com"
       service  = "http://utro-ui.default.svc.cluster.local:3000"
       origin_request {
-        connect_timeout       = "30s"
+        connect_timeout        = "30s"
         keep_alive_connections = 100
-        keep_alive_timeout    = "1m30s"
-        proxy_address         = "127.0.0.1"
-        tcp_keep_alive        = "30s"
-        tls_timeout           = "10s"
+        keep_alive_timeout     = "1m30s"
+        proxy_address          = "127.0.0.1"
+        tcp_keep_alive         = "30s"
+        tls_timeout            = "10s"
       }
     }
     ingress_rule {
       hostname = "utro-test.inspi.cloud"
       service  = "http://utr-staging-ui.default.svc.cluster.local:3000"
       origin_request {
-        connect_timeout       = "30s"
+        connect_timeout        = "30s"
         keep_alive_connections = 100
-        keep_alive_timeout    = "1m30s"
-        proxy_address         = "127.0.0.1"
-        tcp_keep_alive        = "30s"
-        tls_timeout           = "10s"
+        keep_alive_timeout     = "1m30s"
+        proxy_address          = "127.0.0.1"
+        tcp_keep_alive         = "30s"
+        tls_timeout            = "10s"
+      }
+    }
+    # Customer app API (Connect/gRPC). Public — Firebase Bearer tokens are verified by
+    # the customer-gateway itself; Cloudflare Access is bypassed for this host (access.tf).
+    ingress_rule {
+      hostname = "customer-api.inspiration-particle.com"
+      service  = "http://utro-customer-gateway.default.svc.cluster.local:9998"
+      origin_request {
+        connect_timeout        = "30s"
+        keep_alive_connections = 100
+        keep_alive_timeout     = "1m30s"
+        proxy_address          = "127.0.0.1"
+        tcp_keep_alive         = "30s"
+        tls_timeout            = "10s"
+      }
+    }
+    # Customer web/mobile app.
+    ingress_rule {
+      hostname = "app.inspiration-particle.com"
+      service  = "http://utro-customer-ui.default.svc.cluster.local:3000"
+      origin_request {
+        connect_timeout        = "30s"
+        keep_alive_connections = 100
+        keep_alive_timeout     = "1m30s"
+        proxy_address          = "127.0.0.1"
+        tcp_keep_alive         = "30s"
+        tls_timeout            = "10s"
       }
     }
     ingress_rule {

--- a/infra/utro/firebase.tf
+++ b/infra/utro/firebase.tf
@@ -1,0 +1,146 @@
+# ---------------------------------------------------------------------------
+# Firebase Auth / Google Identity Platform for the customer-facing app.
+#
+# Customers authenticate with Firebase (passwordless email link + Google) and
+# their ID tokens are verified by the customer-gateway. This file provisions the
+# Identity Platform config, the Firebase web app (for the frontend SDK config),
+# and a least-privilege service account whose key the gateway uses to verify
+# tokens (incl. revocation checks). Nothing here is applied by CI — run manually.
+# ---------------------------------------------------------------------------
+
+# --- APIs ---------------------------------------------------------------------
+
+resource "google_project_service" "identitytoolkit" {
+  project                    = var.gcp_project_id
+  service                    = "identitytoolkit.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}
+
+resource "google_project_service" "firebase" {
+  project                    = var.gcp_project_id
+  service                    = "firebase.googleapis.com"
+  disable_on_destroy         = false
+  disable_dependent_services = false
+}
+
+# --- Identity Platform config -------------------------------------------------
+
+# Enables Identity Platform on the project and turns on passwordless email
+# (email-link) sign-in. password_required = false is what selects email-link
+# rather than email+password.
+resource "google_identity_platform_config" "auth" {
+  provider = google-beta
+  project  = var.gcp_project_id
+
+  sign_in {
+    allow_duplicate_emails = false
+
+    email {
+      enabled           = true
+      password_required = false
+    }
+  }
+
+  authorized_domains = var.firebase_authorized_domains
+
+  depends_on = [google_project_service.identitytoolkit]
+}
+
+# Google social sign-in. Only created when an OAuth client is supplied, so the
+# base config applies cleanly before you've set up the OAuth consent screen.
+resource "google_identity_platform_default_supported_idp_config" "google" {
+  provider = google-beta
+  count    = var.google_oauth_client_id != "" ? 1 : 0
+
+  project       = var.gcp_project_id
+  enabled       = true
+  idp_id        = "google.com"
+  client_id     = var.google_oauth_client_id
+  client_secret = var.google_oauth_client_secret
+
+  depends_on = [google_identity_platform_config.auth]
+}
+
+# --- Firebase web app (frontend SDK config) -----------------------------------
+
+resource "google_firebase_project" "this" {
+  provider = google-beta
+  project  = var.gcp_project_id
+
+  depends_on = [google_project_service.firebase]
+}
+
+resource "google_firebase_web_app" "customer" {
+  provider     = google-beta
+  project      = var.gcp_project_id
+  display_name = "utro-customer"
+
+  depends_on = [google_firebase_project.this]
+}
+
+# Non-secret client config consumed by the customer-ui build (apiKey, authDomain,
+# appId, messagingSenderId). Safe to expose — Firebase web config is public.
+data "google_firebase_web_app_config" "customer" {
+  provider   = google-beta
+  project    = var.gcp_project_id
+  web_app_id = google_firebase_web_app.customer.app_id
+}
+
+# --- Gateway service account (token verification) -----------------------------
+
+# The customer-gateway verifies ID tokens with the Admin SDK. Plain verification
+# only needs Google's public certs, but revocation checks (checkRevoked) call
+# GetUser, so the SA needs read access to Identity Platform users. firebaseauth
+# viewer is the least-privilege role that grants firebaseauth.users.get.
+resource "google_service_account" "firebase_admin" {
+  project      = var.gcp_project_id
+  account_id   = "utro-customer-gw-fb"
+  display_name = "utro customer-gateway Firebase token verifier"
+}
+
+resource "google_project_iam_member" "firebase_admin_viewer" {
+  project = var.gcp_project_id
+  role    = "roles/firebaseauth.viewer"
+  member  = "serviceAccount:${google_service_account.firebase_admin.email}"
+}
+
+resource "google_service_account_key" "firebase_admin" {
+  service_account_id = google_service_account.firebase_admin.name
+}
+
+# Stored in Secret Manager and surfaced into the cluster via an ExternalSecret
+# (see the customer-gateway deployment). Mirrors the gcp-secrets.tf pattern.
+resource "google_secret_manager_secret" "firebase_admin_credentials" {
+  project   = var.gcp_project_id
+  secret_id = "utro-customer-gateway-firebase-admin"
+
+  replication {
+    auto {}
+  }
+
+  labels = var.tags
+}
+
+resource "google_secret_manager_secret_version" "firebase_admin_credentials" {
+  secret      = google_secret_manager_secret.firebase_admin_credentials.id
+  secret_data = base64decode(google_service_account_key.firebase_admin.private_key)
+}
+
+# --- Outputs ------------------------------------------------------------------
+
+output "firebase_web_config" {
+  description = "Public Firebase web SDK config for the customer-ui build."
+  value = {
+    project_id          = google_firebase_web_app.customer.project
+    app_id              = google_firebase_web_app.customer.app_id
+    api_key             = data.google_firebase_web_app_config.customer.api_key
+    auth_domain         = data.google_firebase_web_app_config.customer.auth_domain
+    messaging_sender_id = try(data.google_firebase_web_app_config.customer.messaging_sender_id, null)
+  }
+}
+
+output "firebase_admin_secret_id" {
+  description = "Secret Manager secret holding the gateway's Firebase Admin SA key."
+  value       = google_secret_manager_secret.firebase_admin_credentials.secret_id
+}

--- a/infra/utro/providers.tf
+++ b/infra/utro/providers.tf
@@ -42,3 +42,23 @@ provider "google" {
   }
 }
 
+# google-beta mirrors the google provider. Firebase / Identity Platform resources
+# (google_firebase_project, google_firebase_web_app, google_identity_platform_*) are
+# only available in the beta provider. It needs the same billing_project /
+# user_project_override as google or Firebase API calls 403 with SERVICE_DISABLED.
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+
+  billing_project       = var.gcp_project_id
+  user_project_override = true
+
+  default_labels = {
+    application = "utro"
+    owner       = "k8s-setup-infra-utro"
+    utro        = "true"
+    terraform   = "true"
+    github      = "k8s-setup"
+  }
+}
+

--- a/infra/utro/terraform.tfvars.example
+++ b/infra/utro/terraform.tfvars.example
@@ -12,6 +12,13 @@ dynamodb_table    = ""
 # GCP
 gcp_project_id = "your-gcp-project-id"
 
+# Firebase / Identity Platform (customer auth)
+# Domains allowed to complete auth flows (email-link continueUrl + OAuth redirect).
+firebase_authorized_domains = ["localhost", "app.your-domain.com"]
+# Google sign-in OAuth client (leave empty to skip the Google IdP for now).
+google_oauth_client_id     = ""
+google_oauth_client_secret = ""
+
 # Set to true to create an IAM user and push its access keys to GCP Secret Manager
 create_user = false
 

--- a/infra/utro/variables.tf
+++ b/infra/utro/variables.tf
@@ -47,6 +47,25 @@ variable "cluster_secret_store_name" {
   default     = "google-secrets"
 }
 
+variable "firebase_authorized_domains" {
+  description = "Domains allowed to complete Firebase auth flows (email-link continueUrl, OAuth redirect). Include the customer web host and localhost for dev."
+  type        = list(string)
+  default     = ["localhost"]
+}
+
+variable "google_oauth_client_id" {
+  description = "OAuth 2.0 client ID for Google sign-in. Leave empty to skip provisioning the Google IdP."
+  type        = string
+  default     = ""
+}
+
+variable "google_oauth_client_secret" {
+  description = "OAuth 2.0 client secret for Google sign-in."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "aws_region" {
     description = "AWS region to create resources in"
     type        = string

--- a/infra/utro/versions.tf
+++ b/infra/utro/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/google"
       version = "6.50.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "6.50.0"
+    }
     local = {
       source  = "hashicorp/local"
       version = "2.5.2"


### PR DESCRIPTION
## What

Infrastructure for the customer-facing app's authentication (Firebase / Google Identity Platform), the customer gateway + UI deployments, and their public Cloudflare routing.

## Changes

**Terraform — `infra/utro/`**
- `firebase.tf` — `google-beta` provider; `identitytoolkit` + `firebase` APIs; `google_identity_platform_config` (passwordless email sign-in); `google_identity_platform_default_supported_idp_config` for Google (guarded to `count=0` until an OAuth client is supplied); `google_firebase_project` + `google_firebase_web_app` + web-config data source; a least-privilege Admin SA (`roles/firebaseauth.viewer`) with its key stored in Secret Manager. Outputs `firebase_web_config` + `firebase_admin_secret_id`.
- `versions.tf` / `providers.tf` — add the `google-beta` provider (mirrors `google`, incl. `billing_project` / `user_project_override`).
- `variables.tf` / `terraform.tfvars.example` — `firebase_authorized_domains`, `google_oauth_client_id/secret`.

**Terraform — `infra/cloudflare/`**
- `tunnel.tf` / `dns.tf` / `access.tf` — public hosts `app.inspiration-particle.com` (UI) and `customer-api.inspiration-particle.com` (gateway), both **Access-bypassed** (auth is enforced by Firebase + the gateway, not Cloudflare Access).

**k8s — `clusters/may-chang/`**
- `utro/customer-gateway-{statefulset,service}.yaml` — the token-verifying gateway (ports 9998/18008, Firebase env, mounted Admin creds).
- `utro/customer-ui-{statefulset,service}.yaml` — the Next.js app (`tcpSocket` probes, since the same bundle static-exports for Capacitor and has no `/api` routes).
- `external-secrets-operator/resources/firebase-admin-secret.yaml` — ExternalSecret feeding the gateway the Admin key from Secret Manager.

## Not applied

No `terraform apply` and nothing deployed. Apply `infra/utro` manually, then feed the `firebase_web_config` output into the customer-ui build. Validated locally only: `terraform fmt`, `kubectl kustomize` (both overlays render).

## Follow-ups before it runs
- Set `gcp_project_id` in `terraform.tfvars` and replace `REPLACE_WITH_GCP_PROJECT_ID` in `customer-gateway-statefulset.yaml` with the **string** project id `danb-ubuntu-k0s` (Firebase tokens carry `aud: <project-id-string>`, so the numeric form fails verification).
- Create the Google OAuth client, then set `google_oauth_client_id/secret` to enable the Google IdP.
- Fill real Apple Team ID / Android SHA-256 in the app's `.well-known/` files (in the utro repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZBMEYvRY8EL88dY5cHJC8
