### PR TITLE
feat(infra): read Google OAuth creds from Secret Manager instead of tfvars

### DIFF
--- a/infra/utro/firebase.tf
+++ b/infra/utro/firebase.tf
@@ -47,17 +47,31 @@ resource "google_identity_platform_config" "auth" {
   depends_on = [google_project_service.identitytoolkit]
 }
 
-# Google social sign-in. Only created when an OAuth client is supplied, so the
-# base config applies cleanly before you've set up the OAuth consent screen.
+# Google social sign-in. The OAuth web-client id/secret live in Secret Manager
+# (populated once via scripts/put-google-oauth-secrets.sh) rather than in tfvars,
+# so no credential is committed or kept on disk. Gated on enable_google_signin so
+# the base config applies cleanly before the secrets exist.
+data "google_secret_manager_secret_version" "google_oauth_client_id" {
+  count   = var.enable_google_signin ? 1 : 0
+  project = var.gcp_project_id
+  secret  = "utro-customer-google-oauth-client-id"
+}
+
+data "google_secret_manager_secret_version" "google_oauth_client_secret" {
+  count   = var.enable_google_signin ? 1 : 0
+  project = var.gcp_project_id
+  secret  = "utro-customer-google-oauth-client-secret"
+}
+
 resource "google_identity_platform_default_supported_idp_config" "google" {
   provider = google-beta
-  count    = var.google_oauth_client_id != "" ? 1 : 0
+  count    = var.enable_google_signin ? 1 : 0
 
   project       = var.gcp_project_id
   enabled       = true
   idp_id        = "google.com"
-  client_id     = var.google_oauth_client_id
-  client_secret = var.google_oauth_client_secret
+  client_id     = data.google_secret_manager_secret_version.google_oauth_client_id[0].secret_data
+  client_secret = data.google_secret_manager_secret_version.google_oauth_client_secret[0].secret_data
 
   depends_on = [google_identity_platform_config.auth]
 }

--- a/infra/utro/scripts/put-google-oauth-secrets.sh
+++ b/infra/utro/scripts/put-google-oauth-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Store the Google OAuth web-client credentials (for customer Google sign-in) in
+# GCP Secret Manager, so they live there instead of in terraform.tfvars.
+#
+# Run ONCE. Re-running just adds a new version (safe). Terraform then reads these
+# via data.google_secret_manager_secret_version in firebase.tf, gated on
+# enable_google_signin = true.
+#
+# Values come from the "Utro Client" OAuth 2.0 Web application client:
+#   GCP Console -> APIs & Services -> Credentials -> Utro Client
+#
+# Usage:
+#   ./put-google-oauth-secrets.sh              # prompts for both values
+#   GCP_PROJECT=danb-ubuntu-k0s ./put-google-oauth-secrets.sh
+set -euo pipefail
+
+PROJECT="${GCP_PROJECT:-danb-ubuntu-k0s}"
+ID_SECRET="utro-customer-google-oauth-client-id"
+SECRET_SECRET="utro-customer-google-oauth-client-secret"
+
+# Prompt without echoing the secret to the terminal / shell history.
+read -rp  "Google OAuth Web client ID:     " CLIENT_ID
+read -rsp "Google OAuth Web client secret: " CLIENT_SECRET
+echo
+
+if [[ -z "${CLIENT_ID}" || -z "${CLIENT_SECRET}" ]]; then
+  echo "error: both the client ID and secret are required" >&2
+  exit 1
+fi
+
+put_secret() {
+  local name="$1" value="$2"
+  if ! gcloud secrets describe "${name}" --project="${PROJECT}" >/dev/null 2>&1; then
+    echo "creating secret ${name}"
+    gcloud secrets create "${name}" \
+      --project="${PROJECT}" \
+      --replication-policy="automatic" \
+      --labels="application=utro,managed-by=script" >/dev/null
+  fi
+  printf '%s' "${value}" | gcloud secrets versions add "${name}" \
+    --project="${PROJECT}" --data-file=- >/dev/null
+  echo "stored new version of ${name}"
+}
+
+put_secret "${ID_SECRET}"     "${CLIENT_ID}"
+put_secret "${SECRET_SECRET}" "${CLIENT_SECRET}"
+
+cat <<EOF
+
+Done. Both secrets are in Secret Manager (project ${PROJECT}).
+
+Next:
+  1. set  enable_google_signin = true  in terraform.tfvars
+  2. terraform apply   (reads the secrets and enables the Google IdP)
+
+Whoever runs terraform needs roles/secretmanager.secretAccessor on these secrets.
+EOF

--- a/infra/utro/terraform.tfvars.example
+++ b/infra/utro/terraform.tfvars.example
@@ -15,9 +15,9 @@ gcp_project_id = "your-gcp-project-id"
 # Firebase / Identity Platform (customer auth)
 # Domains allowed to complete auth flows (email-link continueUrl + OAuth redirect).
 firebase_authorized_domains = ["localhost", "app.your-domain.com"]
-# Google sign-in OAuth client (leave empty to skip the Google IdP for now).
-google_oauth_client_id     = ""
-google_oauth_client_secret = ""
+# Google sign-in. The OAuth web-client id/secret are read from Secret Manager,
+# NOT stored here — run scripts/put-google-oauth-secrets.sh once, then set true.
+enable_google_signin = false
 
 # Set to true to create an IAM user and push its access keys to GCP Secret Manager
 create_user = false

--- a/infra/utro/variables.tf
+++ b/infra/utro/variables.tf
@@ -53,17 +53,10 @@ variable "firebase_authorized_domains" {
   default     = ["localhost"]
 }
 
-variable "google_oauth_client_id" {
-  description = "OAuth 2.0 client ID for Google sign-in. Leave empty to skip provisioning the Google IdP."
-  type        = string
-  default     = ""
-}
-
-variable "google_oauth_client_secret" {
-  description = "OAuth 2.0 client secret for Google sign-in."
-  type        = string
-  default     = ""
-  sensitive   = true
+variable "enable_google_signin" {
+  description = "Enable the Google sign-in IdP. Requires the OAuth web-client id/secret to already be in Secret Manager (run scripts/put-google-oauth-secrets.sh once first)."
+  type        = bool
+  default     = false
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## What

Move the Google sign-in OAuth credentials **out of `terraform.tfvars`** and into **GCP Secret Manager**, so no client secret is kept on disk or in a variables file. Follow-up to #45.

## Why

Google shut down the IAP OAuth Admin API (March 2026), so the OAuth *client* can't be created programmatically — but we can still keep its **id/secret** out of tfvars and source them from Secret Manager at apply time.

## Changes

- **`scripts/put-google-oauth-secrets.sh`** (new) — run once. Prompts for the client id + secret (secret read hidden, never hits shell history), then creates/updates two Secret Manager secrets: `utro-customer-google-oauth-client-id` and `utro-customer-google-oauth-client-secret`. Idempotent.
- **`firebase.tf`** — the Google IdP now reads those via `data.google_secret_manager_secret_version`, gated on a new `enable_google_signin` flag (data sources are `count`-guarded too, so nothing is read until it's enabled).
- **`variables.tf`** — replaced `google_oauth_client_id` / `google_oauth_client_secret` with `enable_google_signin` (bool, default false).
- **`terraform.tfvars.example`** — documents the new flow.

## Usage

1. GCP Console → Credentials → **Utro Client** → copy Client ID + secret; ensure redirect URIs include `https://danb-ubuntu-k0s.firebaseapp.com/__/auth/handler`.
2. `cd infra/utro && ./scripts/put-google-oauth-secrets.sh` → paste both.
3. Set `enable_google_signin = true` in `terraform.tfvars` → `terraform apply`.

## Notes

- Whoever runs `terraform` needs `roles/secretmanager.secretAccessor` on the two secrets.
- The secret still lands in Terraform **state** (data sources fetch the value) — unchanged sensitivity, just no longer in tfvars.
- Not applied. `terraform fmt` clean; `bash -n` on the script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZBMEYvRY8EL88dY5cHJC8
