### PR TITLE
fix(infra): set customer-gateway FIREBASE_PROJECT_ID to danb-ubuntu-k0s

### DIFF
--- a/clusters/may-chang/utro/customer-gateway-statefulset.yaml
+++ b/clusters/may-chang/utro/customer-gateway-statefulset.yaml
@@ -52,10 +52,11 @@ spec:
           value: "prod"
         - name: SERVICE_VERSION
           value: "0.0.1"
-        # Firebase / Identity Platform. FIREBASE_PROJECT_ID must match the project the
-        # customer ID tokens are issued for (the same project as infra/utro firebase.tf).
+        # Firebase / Identity Platform. Must be the string project ID (not the
+        # number): Firebase ID tokens carry aud=danb-ubuntu-k0s, so the numeric
+        # form fails verification.
         - name: FIREBASE_PROJECT_ID
-          value: "REPLACE_WITH_GCP_PROJECT_ID"
+          value: "danb-ubuntu-k0s"
         - name: FIREBASE_CHECK_REVOKED
           value: "true"
         - name: FIREBASE_CREDENTIALS_FILE


### PR DESCRIPTION
The customer-gateway StatefulSet (from #45) shipped a `REPLACE_WITH_GCP_PROJECT_ID` placeholder for `FIREBASE_PROJECT_ID`.

Firebase ID tokens carry `aud=<project-id-string>`, so the numeric project number fails token verification — set it to the string id `danb-ubuntu-k0s`.

kubectl kustomize renders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZBMEYvRY8EL88dY5cHJC8